### PR TITLE
Convert the return object to a string so that Jackson doesn't try to …

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/MatchResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/MatchResource.java
@@ -43,7 +43,7 @@ public class MatchResource {
                         System.out.println("Failure: " + failure.getMessage());
                         response.resume(new WebApplicationException(failure));
                     } else {
-                        response.resume(ImmutableMap.of("result", result, "matchPair", matchPair));
+                        response.resume(ImmutableMap.of("result", result, "matchPair", matchPair).toString());
                     }
                 }
             },


### PR DESCRIPTION
…deserialize the members twice.
