### PR TITLE
GAWB-1571: autocomplete lookup always honors deprecation flag from ontology

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteAPI.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteAPI.java
@@ -57,15 +57,18 @@ public class ElasticSearchAutocompleteAPI implements AutocompleteAPI {
 
     @Override
     public List<TermResource> lookup(String query, int limit) {
-        return executeSearch(buildQuery(query), limit);
+        return lookup(new String[0], query, limit);
     }
 
     @Override
     public List<TermResource> lookup(String[] tags, String query, int limit) {
-        FilterBuilder filter = FilterBuilders.andFilter(
-                FilterBuilders.termFilter(FIELD_USABLE, true),
-                FilterBuilders.termsFilter(FIELD_ONTOLOGY_TYPE, tags)
-        );
+        FilterBuilder deprecationFilter = FilterBuilders.termFilter(FIELD_USABLE, true);
+        FilterBuilder filter;
+        if (tags.length > 0) {
+            filter = FilterBuilders.andFilter(deprecationFilter, FilterBuilders.termsFilter(FIELD_ONTOLOGY_TYPE, tags));
+        } else {
+            filter = deprecationFilter;
+        }
         QueryBuilder queryBuilder = buildQuery(query);
         return executeSearch(QueryBuilders.filteredQuery(queryBuilder, filter), limit);
     }


### PR DESCRIPTION
both `lookup` methods in ElasticSearchAutocompleteAPI.java now honor the deprecation status of ontology nodes. I implemented this by having one `lookup` delegate to the other one to ensure consistency.


- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] Tell tech lead that the PR exists
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [x] Comment / review / update cycle:
  * Rest of team may comments on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter updates documentation as needed
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
