### PR TITLE
Ignore unknown props in config

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyConfiguration.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyConfiguration.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.dsde.consent.ontology;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import org.broadinstitute.dsde.consent.ontology.configurations.*;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OntologyConfiguration extends Configuration {
 
 


### PR DESCRIPTION
No jira - allow for unknown props in configuration for easier implementation of future features.