### PR TITLE
[BTRX-452][risk=no] ES health check  refactoring

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -56,7 +56,7 @@ public class OntologyApp extends Application<OntologyConfiguration> {
 
         ElasticSearchConfiguration esConfig = config.getElasticSearchConfiguration();
         env.healthChecks().register(ElasticSearchHealthCheck.NAME, injector.getInstance(ElasticSearchHealthCheck.class));
-        env.jersey().register(new StatusResource(env.healthChecks()));
+        env.jersey().register(injector.getInstance(StatusResource.class));
 
         FilterRegistration.Dynamic corsFilter = env.servlets().addFilter("CORS", CrossOriginFilter.class);
         corsFilter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, env.getApplicationContext().getContextPath() + "/autocomplete");

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -55,7 +55,7 @@ public class OntologyApp extends Application<OntologyConfiguration> {
         env.jersey().register(injector.getInstance(SwaggerResource.class));
 
         ElasticSearchConfiguration esConfig = config.getElasticSearchConfiguration();
-        env.healthChecks().register("elastic-search", new ElasticSearchHealthCheck(esConfig));
+        env.healthChecks().register(ElasticSearchHealthCheck.NAME, injector.getInstance(ElasticSearchHealthCheck.class));
         env.jersey().register(new StatusResource(env.healthChecks()));
 
         FilterRegistration.Dynamic corsFilter = env.servlets().addFilter("CORS", CrossOriginFilter.class);

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
@@ -8,6 +8,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSStore;
+import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationService;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchAutocomplete;
@@ -55,5 +56,11 @@ public class OntologyModule extends AbstractModule {
             config.getStoreOntologyConfiguration().getBucketSubdirectory(),
             config.getStoreOntologyConfiguration().getConfigurationFileName());
     }
+
+    @Provides
+    public ElasticSearchConfiguration providesElasticSearchConfiguration() {
+        return config.getElasticSearchConfiguration();
+    }
+
 }
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.consent.ontology;
 
+import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
@@ -60,6 +61,11 @@ public class OntologyModule extends AbstractModule {
     @Provides
     public ElasticSearchConfiguration providesElasticSearchConfiguration() {
         return config.getElasticSearchConfiguration();
+    }
+
+    @Provides
+    public HealthCheckRegistry providesHealthCheckRegistry() {
+        return environment.healthChecks();
     }
 
 }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.consent.ontology.resources;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
+import com.google.inject.Inject;
 import org.apache.log4j.Logger;
 
 import javax.ws.rs.GET;
@@ -19,6 +20,7 @@ public class StatusResource {
 
     private HealthCheckRegistry healthChecks;
 
+    @Inject
     public StatusResource(HealthCheckRegistry healthChecks) {
         this.healthChecks = healthChecks;
     }


### PR DESCRIPTION
Small refactoring PR in my effort to make some progress on https://broadinstitute.atlassian.net/browse/BTRX-452

blocked on https://github.com/DataBiosphere/consent-ontology/pull/125

The goal with this set of stacked PRs is to clean up how we're using guice now so I can have a cleaner model to follow when updating consent. Consent will have some of the same problems we had here, but worse.
See also:
* https://github.com/DataBiosphere/consent-ontology/pull/124
* https://github.com/DataBiosphere/consent-ontology/pull/125
* https://github.com/DataBiosphere/consent-ontology/pull/127
