### PR TITLE
[BTRX-452][risk=no] Use constructor injection

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.consent.ontology;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
@@ -12,6 +11,7 @@ import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSStore;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.dsde.consent.ontology.datause.api.LuceneOntologyTermSearchAPI;
 import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationService;
+import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationServiceImpl;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchAutocomplete;
 import org.broadinstitute.dsde.consent.ontology.service.StoreOntologyService;
@@ -35,7 +35,12 @@ public class OntologyModule extends AbstractModule {
     protected void configure() {
         bind(Configuration.class).toInstance(config);
         bind(Environment.class).toInstance(environment);
-        bind(TextTranslationService.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    public TextTranslationService providesTextTranslationService() {
+        return new TextTranslationServiceImpl(providesAutocomplete());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
@@ -10,11 +10,13 @@ import io.dropwizard.setup.Environment;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSStore;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.dsde.consent.ontology.datause.api.LuceneOntologyTermSearchAPI;
 import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationService;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchAutocomplete;
 import org.broadinstitute.dsde.consent.ontology.service.StoreOntologyService;
 import org.broadinstitute.dsde.consent.ontology.service.validate.UseRestrictionValidationService;
+import org.broadinstitute.dsde.consent.ontology.service.validate.UseRestrictionValidator;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -33,8 +35,14 @@ public class OntologyModule extends AbstractModule {
     protected void configure() {
         bind(Configuration.class).toInstance(config);
         bind(Environment.class).toInstance(environment);
-        bind(UseRestrictionValidationService.class).in(Scopes.SINGLETON);
         bind(TextTranslationService.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    public UseRestrictionValidationService providesUseRestrictionValidationService() {
+        LuceneOntologyTermSearchAPI service = new LuceneOntologyTermSearchAPI(providesStore());
+        return new UseRestrictionValidator(service);
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationService.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationService.java
@@ -1,10 +1,7 @@
 package org.broadinstitute.dsde.consent.ontology.datause.services;
 
-import com.google.inject.ImplementedBy;
-
 import java.io.IOException;
 
-@ImplementedBy(TextTranslationServiceImpl.class)
 public interface TextTranslationService {
 
     enum TranslateFor { DATASET, PURPOSE }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/validate/UseRestrictionValidationService.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/validate/UseRestrictionValidationService.java
@@ -1,8 +1,5 @@
 package org.broadinstitute.dsde.consent.ontology.service.validate;
 
-import com.google.inject.ImplementedBy;
-
-@ImplementedBy(UseRestrictionValidator.class)
 public interface UseRestrictionValidationService {
 
     ValidateResponse validateUseRestriction(String useRestriction) throws Exception;

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/validate/UseRestrictionValidator.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/validate/UseRestrictionValidator.java
@@ -1,29 +1,27 @@
 package org.broadinstitute.dsde.consent.ontology.service.validate;
 
-
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import org.apache.log4j.Logger;
 import org.broadinstitute.dsde.consent.ontology.datause.api.OntologyTermSearchAPI;
 import org.broadinstitute.dsde.consent.ontology.datause.models.OntologyTerm;
 import org.broadinstitute.dsde.consent.ontology.datause.models.UseRestriction;
 import org.broadinstitute.dsde.consent.ontology.datause.models.visitor.NamedVisitor;
 import org.broadinstitute.dsde.consent.ontology.enumerations.UseRestrictionKeys;
-import java.util.HashSet;
+
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Singleton
 public class UseRestrictionValidator implements UseRestrictionValidationService {
 
     private final Logger log = Logger.getLogger(UseRestrictionValidator.class);
     private OntologyTermSearchAPI ontologyTermSearchAPI;
 
     @Inject
-    public void setOntologySearchTermAPI(OntologyTermSearchAPI ontologyTermSearchAPI) {
+    public UseRestrictionValidator(OntologyTermSearchAPI ontologyTermSearchAPI) {
         this.ontologyTermSearchAPI = ontologyTermSearchAPI;
     }
 
@@ -49,7 +47,7 @@ public class UseRestrictionValidator implements UseRestrictionValidationService 
             }
             if(invalidTerms.size() > 0){
                 isValid.setValid(false);
-                isValid.addError("Term not found: " + invalidTerms.stream().collect(Collectors.joining(", ")));
+                isValid.addError("Term not found: " + String.join(", ", invalidTerms));
             }
         }
         catch(UnrecognizedPropertyException e){

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/validate/UseRestrictionValidatorTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/validate/UseRestrictionValidatorTest.java
@@ -23,8 +23,7 @@ public class UseRestrictionValidatorTest extends AbstractTest {
     public static void setUpClass() throws Exception {
         StoreOntologyService storeOntologyServiceMock = getStorageServiceMock();
         OntologyTermSearchAPI api = new LuceneOntologyTermSearchAPI(storeOntologyServiceMock);
-        service = new UseRestrictionValidator();
-        service.setOntologySearchTermAPI(api);
+        service = new UseRestrictionValidator(api);
     }
 
     /**


### PR DESCRIPTION
Small refactoring PR in my effort to make some progress on https://broadinstitute.atlassian.net/browse/BTRX-452

Makes no functional changes, changing to constructor injection

The goal with this set of stacked PRs is to clean up how we're using guice now so I can have a cleaner model to follow when updating consent. Consent will have some of the same problems we had here, but worse.
See also:
* https://github.com/DataBiosphere/consent-ontology/pull/124
* https://github.com/DataBiosphere/consent-ontology/pull/125
* https://github.com/DataBiosphere/consent-ontology/pull/126
* https://github.com/DataBiosphere/consent-ontology/pull/127
* https://github.com/DataBiosphere/consent-ontology/pull/129