### PR TITLE
[BTRX-452][risk=no] Use constructor injection

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyModule.java
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.consent.ontology;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Environment;
@@ -12,6 +11,7 @@ import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSStore;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.dsde.consent.ontology.datause.api.LuceneOntologyTermSearchAPI;
 import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationService;
+import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationServiceImpl;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchAutocomplete;
 import org.broadinstitute.dsde.consent.ontology.service.StoreOntologyService;
@@ -35,7 +35,12 @@ public class OntologyModule extends AbstractModule {
     protected void configure() {
         bind(Configuration.class).toInstance(config);
         bind(Environment.class).toInstance(environment);
-        bind(TextTranslationService.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    public TextTranslationService providesTextTranslationService() {
+        return new TextTranslationServiceImpl(providesAutocomplete());
     }
 
     @Provides

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationService.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationService.java
@@ -1,10 +1,7 @@
 package org.broadinstitute.dsde.consent.ontology.datause.services;
 
-import com.google.inject.ImplementedBy;
-
 import java.io.IOException;
 
-@ImplementedBy(TextTranslationServiceImpl.class)
 public interface TextTranslationService {
 
     enum TranslateFor { DATASET, PURPOSE }


### PR DESCRIPTION
Small refactoring PR in my effort to make some progress on https://broadinstitute.atlassian.net/browse/BTRX-452

Makes no functional changes, changing to constructor injection

The goal with this set of stacked PRs is to clean up how we're using guice now so I can have a cleaner model to follow when updating consent. Consent will have some of the same problems we had here, but worse.
See also:
* https://github.com/DataBiosphere/consent-ontology/pull/124
* https://github.com/DataBiosphere/consent-ontology/pull/125
* https://github.com/DataBiosphere/consent-ontology/pull/126
* https://github.com/DataBiosphere/consent-ontology/pull/127
* https://github.com/DataBiosphere/consent-ontology/pull/128