### PR TITLE
[BTRX-525][risk=no] Version Endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,40 @@
     <build>
         <finalName>consent-ontology</finalName>
         <plugins>
-
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.5</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>validate-the-git-infos</id>
+                        <goals>
+                            <goal>validateRevision</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <prefix>git</prefix>
+                    <verbose>false</verbose>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <format>json</format>
+                    <gitDescribe>
+                        <skip>true</skip>
+                        <always>false</always>
+                        <dirty>-dirty</dirty>
+                    </gitDescribe>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.broadinstitute</groupId>
     <artifactId>consent-ontology</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
     <name>Consent Management: Ontology Services</name>
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.consent.ontology.resources.OntologySearchResource
 import org.broadinstitute.dsde.consent.ontology.resources.StatusResource;
 import org.broadinstitute.dsde.consent.ontology.resources.SwaggerResource;
 import org.broadinstitute.dsde.consent.ontology.resources.TranslateResource;
+import org.broadinstitute.dsde.consent.ontology.resources.VersionResource;
 import org.broadinstitute.dsde.consent.ontology.resources.validate.ValidationResource;
 import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchHealthCheck;
 import org.dhatim.dropwizard.sentry.logging.SentryBootstrap;
@@ -53,6 +54,7 @@ public class OntologyApp extends Application<OntologyConfiguration> {
         env.jersey().register(injector.getInstance(OntologySearchResource.class));
         env.jersey().register(injector.getInstance(DataUseResource.class));
         env.jersey().register(injector.getInstance(SwaggerResource.class));
+        env.jersey().register(injector.getInstance(VersionResource.class));
 
         env.healthChecks().register(ElasticSearchHealthCheck.NAME, injector.getInstance(ElasticSearchHealthCheck.class));
         env.healthChecks().register(GCSHealthCheck.NAME, injector.getInstance(GCSHealthCheck.class));

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/VersionResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/VersionResource.java
@@ -1,0 +1,64 @@
+package org.broadinstitute.dsde.consent.ontology.resources;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+@Path("/version")
+public class VersionResource {
+
+    private final Logger log = LoggerFactory.getLogger(VersionResource.class);
+
+    @GET
+    @Produces("application/json")
+    public Response content() {
+        Version version = new Version(getGitProperties());
+        return Response.ok().entity(version).build();
+    }
+
+    private String getGitProperties() {
+        try {
+            return IOUtils.resourceToString("/git.properties", Charset.defaultCharset());
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return null;
+    }
+
+    private class Version {
+        String hash;
+        String version;
+
+        Version(String props) {
+            if (props == null) {
+                this.hash = "error";
+                this.version = "error";
+            } else {
+                JsonObject jsonObject = new Gson().fromJson(props, JsonObject.class);
+                JsonElement shortHash = jsonObject.get("git.commit.id.abbrev");
+                JsonElement buildVersion = jsonObject.get("git.build.version");
+                this.hash = Optional.ofNullable(shortHash.getAsString()).orElse("error");
+                this.version = Optional.ofNullable(buildVersion.getAsString()).orElse("error");
+            }
+        }
+
+        public String getHash() {
+            return hash;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+    }
+
+}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -304,9 +304,9 @@ definitions:
   Version:
     type: object
     properties:
-      version:
-        type: string
-        description: Current version
       hash:
         type: string
         description: Current short hash of this version
+      version:
+        type: string
+        description: Current version

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -216,6 +216,19 @@ paths:
         200: All systems are OK
         500: Some number of subsystems are not OK.
 
+  /version:
+    get:
+      summary: Current application version
+      description: The current short hash and snapshot version of the application.
+      tags:
+        - Status
+      responses:
+        200:
+          description: Successful Response
+          schema:
+            $ref: '#/definitions/Version'
+        500: Internal Server Error
+
 definitions:
   Restriction:
     type: object
@@ -287,3 +300,13 @@ definitions:
       matchPair:
         $ref: '#/definitions/DataUseMatchPair'
         description: The provided purpose and consent
+
+  Version:
+    type: object
+    properties:
+      version:
+        type: string
+        description: Current version
+      hash:
+        type: string
+        description: Current short hash of this version

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -219,7 +219,7 @@ paths:
   /version:
     get:
       summary: Current application version
-      description: The current short hash and snapshot version of the application.
+      description: The current short hash and version of the application.
       tags:
         - Status
       responses:

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/VersionResourceTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/VersionResourceTest.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.dsde.consent.ontology.resources;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+public class VersionResourceTest {
+
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new VersionResource())
+            .build();
+
+
+    @Test
+    public void testGetVersion() {
+        Response response = resources.target("/version").request().get();
+        Assert.assertEquals(response.getStatus(), 200);
+    }
+
+}

--- a/src/test/resources/git.properties
+++ b/src/test/resources/git.properties
@@ -1,0 +1,21 @@
+{
+    "git.branch" : "test",
+    "git.build.host" : "host",
+    "git.build.time" : "2019-01-25T11:15:09-0500",
+    "git.build.user.email" : "grushton@broadinstitute.org",
+    "git.build.user.name" : "Greg Rushton",
+    "git.build.version" : "0.1.0-SNAPSHOT",
+    "git.closest.tag.commit.count" : "",
+    "git.closest.tag.name" : "",
+    "git.commit.id" : "long-hash",
+    "git.commit.id.abbrev" : "short-hash",
+    "git.commit.message.full" : "long commit",
+    "git.commit.message.short" : "short commit",
+    "git.commit.time" : "2019-01-24T09:07:21-0500",
+    "git.commit.user.email" : "rushtong@users.noreply.github.com",
+    "git.commit.user.name" : "Greg Rushton",
+    "git.dirty" : "true",
+    "git.remote.origin.url" : "git@github.com:DataBiosphere/consent-ontology.git",
+    "git.tags" : "",
+    "git.total.commit.count" : "237"
+}


### PR DESCRIPTION
## Addresses
The ontology component of [BTRX-525](https://broadinstitute.atlassian.net/browse/BTRX-525)
Adds a simple unauthenticated `/version` endpoint that returns a short hash and the version as defined in pom.xml

See also: https://github.com/DataBiosphere/consent/pull/330

```
{
    "hash": "3650865",
    "version": "0.1.0-SNAPSHOT"
}
```