### PR TITLE
[DUOS-218][risk=no] Serve swagger from root

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.broadinstitute</groupId>
     <artifactId>consent-ontology</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
     <name>Consent Management: Ontology Services</name>
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
@@ -11,10 +11,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-@Path("/swagger")
+@Path("/")
 public class SwaggerResource {
 
     private static final Logger logger = Logger.getLogger(SwaggerResource.class.getName());
@@ -48,6 +50,18 @@ public class SwaggerResource {
 
     @Context
     UriInfo uriInfo;
+
+    @GET
+    @Path("")
+    public Response main() {
+        return content("");
+    }
+
+    @GET
+    @Path("swagger")
+    public Response swagger() throws URISyntaxException {
+        return Response.seeOther(new URI("/")).build();
+    }
 
     @GET
     @Path("{path:.*}")

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.io.InputStream;
 import java.net.URI;
@@ -60,7 +61,8 @@ public class SwaggerResource {
     @GET
     @Path("swagger")
     public Response swagger() throws URISyntaxException {
-        return Response.seeOther(new URI("/")).build();
+        URI uri = UriBuilder.fromPath("/").scheme("https").build();
+        return Response.seeOther(uri).build();
     }
 
     @GET


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/DUOS-218

Currently, the root url is a 404. Instead, serve the swagger page.