### PR TITLE
make gcloud docker auth revoke optional

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -110,7 +110,7 @@ function cleanup()
 {
     echo "cleaning up..."
     if [[ -n $SERVICE_ACCT_KEY_FILE ]]; then
-      gcloud auth revoke
+      gcloud auth revoke && echo 'Token revoke succeeded' || echo 'Token revoke failed -- skipping'
       rm -rf ${CLOUDSDK_CONFIG}
     fi
 }


### PR DESCRIPTION
This fixes an error in the jenkins build:
```
ERROR: gcloud crashed (TokenRevokeError): invalid_request
```
See also https://github.com/DataBiosphere/consent/pull/332