### PR TITLE
[DUOS=233] Upgrade lucene

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <pellet.version>2.3.6-ansell</pellet.version>
         <owl.version>5.0.5</owl.version>
         <jena.version>2.6.4</jena.version>
-        <lucene.version>4.9.0</lucene.version>
+        <lucene.version>[7.1.0,)</lucene.version>
         <dropwizard.version>1.3.7</dropwizard.version>
         <metrics.version>4.0.3</metrics.version>
         <akka.version>2.4.20</akka.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <pellet.version>2.3.6-ansell</pellet.version>
         <owl.version>5.0.5</owl.version>
         <jena.version>2.6.4</jena.version>
-        <lucene.version>[7.1.0,)</lucene.version>
+        <lucene.version>7.1.0</lucene.version>
         <dropwizard.version>1.3.7</dropwizard.version>
         <metrics.version>4.0.3</metrics.version>
         <akka.version>2.4.20</akka.version>

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/api/LuceneOntologyTermSearchAPI.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/api/LuceneOntologyTermSearchAPI.java
@@ -2,15 +2,9 @@ package org.broadinstitute.dsde.consent.ontology.datause.api;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.TextField;
-import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.RAMDirectory;
 import org.broadinstitute.dsde.consent.ontology.datause.models.OntologyTerm;
 import org.broadinstitute.dsde.consent.ontology.service.StoreOntologyService;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -65,109 +59,94 @@ public class LuceneOntologyTermSearchAPI implements OntologyTermSearchAPI {
     }
 
     private void initAPI() throws OWLOntologyCreationException, IOException {
-
         Collection<String> resources = storeOntologyService.retrieveConfigurationKeys();
-        Directory indexDirectory = new RAMDirectory();
+        for (String resource : resources) {
+            try (InputStream stream = new URL(resource).openStream()) {
+                OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+                OWLOntology ontology = manager.loadOntologyFromOntologyDocument(stream);
+                HashMap<String, OWLAnnotationProperty> annotationProperties = new HashMap<>();
 
-        Analyzer analyzer = new StandardAnalyzer();
+                ontology.annotationPropertiesInSignature().forEach((property) -> {
+                    if (property.getIRI().getRemainder().isPresent()) {
+                        annotationProperties.put(property.getIRI().getRemainder().get(), property);
+                    }
+                });
 
-        try (IndexWriter indexWriter = new IndexWriter(indexDirectory,
-                new IndexWriterConfig(analyzer))) {
-            for (String resource : resources) {
-                try (InputStream stream = new URL(resource).openStream()) {
-                    OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
-                    OWLOntology ontology = manager.loadOntologyFromOntologyDocument(stream);
-                    HashMap<String, OWLAnnotationProperty> annotationProperties = new HashMap<>();
+                OWLAnnotationProperty hasExactSynonym = annotationProperties.get("hasExactSynonym");
+                OWLAnnotationProperty label = annotationProperties.get("label");
+                OWLAnnotationProperty comment = annotationProperties.get("comment");
+                OWLAnnotationProperty def = annotationProperties.get(FIELD_DEFINITION_CLASS);
+                OWLAnnotationProperty deprecated = annotationProperties.get("deprecated");
 
-                    ontology.annotationPropertiesInSignature().forEach((property) -> {
-                        if (property.getIRI().getRemainder().isPresent()) {
-                            annotationProperties.put(property.getIRI().getRemainder().get(), property);
+                Set<OWLClass> owlClasses = ontology.classesInSignature().collect(Collectors.toSet());
+                owlClasses.addAll(ontology.
+                        directImports().
+                        flatMap(HasClassesInSignature::classesInSignature).
+                        collect(Collectors.toSet()));
+
+                owlClasses.forEach((OWLClass owlClass) -> {
+                    OWLAnnotationValueVisitorEx<String> visitor = new OWLAnnotationValueVisitorEx<String>() {
+                        @Override
+                        public String visit(IRI iri) {
+                            return iri.toString();
                         }
-                    });
 
-                    OWLAnnotationProperty hasExactSynonym = annotationProperties.get("hasExactSynonym");
-                    OWLAnnotationProperty label = annotationProperties.get("label");
-                    OWLAnnotationProperty comment = annotationProperties.get("comment");
-                    OWLAnnotationProperty def = annotationProperties.get(FIELD_DEFINITION_CLASS);
-                    OWLAnnotationProperty deprecated = annotationProperties.get("deprecated");
+                        @Override
+                        public String visit(OWLAnonymousIndividual owlAnonymousIndividual) {
+                            return owlAnonymousIndividual.toStringID();
+                        }
 
-                    Set<OWLClass> owlClasses = ontology.classesInSignature().collect(Collectors.toSet());
-                    owlClasses.addAll(ontology.
-                            directImports().
-                            flatMap(HasClassesInSignature::classesInSignature).
-                            collect(Collectors.toSet()));
+                        @Override
+                        public String visit(OWLLiteral owlLiteral) {
+                            return owlLiteral.getLiteral();
+                        }
+                    };
 
-                    owlClasses.forEach((OWLClass owlClass) -> {
-                        OWLAnnotationValueVisitorEx<String> visitor = new OWLAnnotationValueVisitorEx<String>() {
-                            @Override
-                            public String visit(IRI iri) {
-                                return iri.toString();
-                            }
-
-                            @Override
-                            public String visit(OWLAnonymousIndividual owlAnonymousIndividual) {
-                                return owlAnonymousIndividual.toStringID();
-                            }
-
-                            @Override
-                            public String visit(OWLLiteral owlLiteral) {
-                                return owlLiteral.getLiteral();
-                            }
-                        };
-
-                        // Do not index deprecated classes.
-                        if (!(deprecated != null && EntitySearcher.getAnnotations(owlClass, ontology, deprecated).count() > 0)) {
-                            Document document = new Document();
-                            if (hasExactSynonym != null) {
-                                EntitySearcher.getAnnotations(owlClass, ontology, hasExactSynonym).forEach((synonyms) ->
-                                        document.add(new TextField(FIELD_SYNONYM, synonyms.getValue().accept(visitor), Field.Store.YES)));
-                            }
-                            if (label != null) {
-                                Stream<OWLAnnotation> labels = EntitySearcher.getAnnotations(owlClass, ontology, label);
-                                ArrayList<OWLAnnotation> labelsList = labels.collect(Collectors.toCollection(ArrayList::new));
-                                assert labelsList.size() <= 1 : "Exactly 0 or 1 labels allowed per class";
-                                if (labelsList.size() == 1) {
-                                    document.add(new TextField(FIELD_LABEL, labelsList.stream().iterator().next().getValue().accept(visitor), Field.Store.YES));
-                                }
-                            }
-                            if (comment != null) {
-                                Stream<OWLAnnotation> comments = EntitySearcher.getAnnotations(owlClass, ontology, comment);
-                                ArrayList<OWLAnnotation> commentsList = comments.collect(Collectors.toCollection(ArrayList::new));
-
-                                assert commentsList.size() <= 1 : "Exactly 0 or 1 comments allowed per class";
-                                if (commentsList.size() == 1) {
-                                    document.add(new TextField(FIELD_COMMENT, commentsList.stream().iterator().next().getValue().accept(visitor), Field.Store.YES));
-                                }
-                            }
-                            if (def != null) {
-                                Stream<OWLAnnotation> defs = EntitySearcher.getAnnotations(owlClass, ontology, def);
-                                ArrayList<OWLAnnotation> defsList = defs.collect(Collectors.toCollection(ArrayList::new));
-                                assert defsList.size() <= 1 : "Exactly 0 or 1 definitions allowed per class";
-                                if (defsList.size() == 1) {
-                                    document.add(new TextField(FIELD_DEFINITION, defsList.stream().iterator().next().getValue().accept(visitor), Field.Store.YES));
-                                }
-                            }
-                            document.add(new TextField(FIELD_ID, owlClass.toStringID(), Field.Store.YES));
-                            nameToTerm.put(document.get(FIELD_ID),
-                                    new OntologyTerm(
-                                            document.get(FIELD_ID),
-                                            document.get(FIELD_COMMENT),
-                                            document.get(FIELD_LABEL),
-                                            document.get(FIELD_DEFINITION),
-                                            document.getValues(FIELD_SYNONYM)));
-
-
-                            try {
-                                indexWriter.addDocument(document);
-                            } catch (IOException e) {
-                                throw new RuntimeException(e.getMessage());
+                    // Do not index deprecated classes.
+                    if (!(deprecated != null && EntitySearcher.getAnnotations(owlClass, ontology, deprecated).count() > 0)) {
+                        Document document = new Document();
+                        if (hasExactSynonym != null) {
+                            EntitySearcher.getAnnotations(owlClass, ontology, hasExactSynonym).forEach((synonyms) ->
+                                    document.add(new TextField(FIELD_SYNONYM, synonyms.getValue().accept(visitor), Field.Store.YES)));
+                        }
+                        if (label != null) {
+                            Stream<OWLAnnotation> labels = EntitySearcher.getAnnotations(owlClass, ontology, label);
+                            ArrayList<OWLAnnotation> labelsList = labels.collect(Collectors.toCollection(ArrayList::new));
+                            assert labelsList.size() <= 1 : "Exactly 0 or 1 labels allowed per class";
+                            if (labelsList.size() == 1) {
+                                document.add(new TextField(FIELD_LABEL, labelsList.stream().iterator().next().getValue().accept(visitor), Field.Store.YES));
                             }
                         }
-                    });
-                } catch (MalformedURLException e) {
-                    log.error("Unable to parse string to url: " + e.getMessage());
-                    throw new RuntimeException(e);
-                }
+                        if (comment != null) {
+                            Stream<OWLAnnotation> comments = EntitySearcher.getAnnotations(owlClass, ontology, comment);
+                            ArrayList<OWLAnnotation> commentsList = comments.collect(Collectors.toCollection(ArrayList::new));
+
+                            assert commentsList.size() <= 1 : "Exactly 0 or 1 comments allowed per class";
+                            if (commentsList.size() == 1) {
+                                document.add(new TextField(FIELD_COMMENT, commentsList.stream().iterator().next().getValue().accept(visitor), Field.Store.YES));
+                            }
+                        }
+                        if (def != null) {
+                            Stream<OWLAnnotation> defs = EntitySearcher.getAnnotations(owlClass, ontology, def);
+                            ArrayList<OWLAnnotation> defsList = defs.collect(Collectors.toCollection(ArrayList::new));
+                            assert defsList.size() <= 1 : "Exactly 0 or 1 definitions allowed per class";
+                            if (defsList.size() == 1) {
+                                document.add(new TextField(FIELD_DEFINITION, defsList.stream().iterator().next().getValue().accept(visitor), Field.Store.YES));
+                            }
+                        }
+                        document.add(new TextField(FIELD_ID, owlClass.toStringID(), Field.Store.YES));
+                        nameToTerm.put(document.get(FIELD_ID),
+                                new OntologyTerm(
+                                        document.get(FIELD_ID),
+                                        document.get(FIELD_COMMENT),
+                                        document.get(FIELD_LABEL),
+                                        document.get(FIELD_DEFINITION),
+                                        document.getValues(FIELD_SYNONYM)));
+                    }
+                });
+            } catch (MalformedURLException e) {
+                log.error("Unable to parse string to url: " + e.getMessage());
+                throw new RuntimeException(e);
             }
         }
     }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/api/LuceneOntologyTermSearchAPI.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/api/LuceneOntologyTermSearchAPI.java
@@ -11,11 +11,20 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
-import org.apache.lucene.util.Version;
 import org.broadinstitute.dsde.consent.ontology.datause.models.OntologyTerm;
 import org.broadinstitute.dsde.consent.ontology.service.StoreOntologyService;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.HasClassesInSignature;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAnnotationValueVisitorEx;
+import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLLiteral;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +33,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -56,10 +69,10 @@ public class LuceneOntologyTermSearchAPI implements OntologyTermSearchAPI {
         Collection<String> resources = storeOntologyService.retrieveConfigurationKeys();
         Directory indexDirectory = new RAMDirectory();
 
-        Analyzer analyzer = new StandardAnalyzer(Version.LUCENE_4_9);
+        Analyzer analyzer = new StandardAnalyzer();
 
         try (IndexWriter indexWriter = new IndexWriter(indexDirectory,
-                new IndexWriterConfig(Version.LUCENE_4_9, analyzer))) {
+                new IndexWriterConfig(analyzer))) {
             for (String resource : resources) {
                 try (InputStream stream = new URL(resource).openStream()) {
                     OWLOntologyManager manager = OWLManager.createOWLOntologyManager();


### PR DESCRIPTION
## Addresses 
https://broadinstitute.atlassian.net/browse/DUOS-233

## Changes
This should fix [the alert that shows up on the github home page](https://github.com/DataBiosphere/consent-ontology/network/alert/pom.xml/org.apache.lucene:lucene-core/open):
![Screen Shot 2019-03-29 at 8 00 52 PM](https://user-images.githubusercontent.com/116679/55268117-687d7780-525d-11e9-8ac4-ed9879d5ba1a.png)

> 1 org.apache.lucene:lucene-core vulnerability found in pom.xml on Oct 17, 2018
> Remediation
> Upgrade org.apache.lucene:lucene-core to version 7.1.0 or later. For example:
> 
```
<dependency>
   <groupId>org.apache.lucene</groupId>
   <artifactId>lucene-core</artifactId>
   <version>[7.1.0,)</version>
 </dependency>
```
> Always verify the validity and compatibility of suggestions with your codebase.
> 
> 
> Details
> CVE-2017-12629 More information
> high severity
> Vulnerable versions: < 7.1.0
> Patched version: 7.1.0
> Remote code execution occurs in Apache Solr before 7.1 with Apache Lucene before 7.1 by exploiting XXE in conjunction with use of a Config API add-listener command to reach the RunExecutableListener class. Elasticsearch, although it uses Lucene, is NOT vulnerable to this. Note that the XML external entity expansion vulnerability occurs in the XML Query Parser which is available, by default, for any query request with parameters deftype=xmlparser and can be exploited to upload malicious data to the /upload request handler or as Blind XXE using ftp wrapper in order to read arbitrary local files from the Solr server. Note also that the second vulnerability relates to remote code execution using the RunExecutableListener available on all affected versions of Solr.
> 

## Testing
Manually tested by running all smoke tests. 

```
Ontology Smoke Tests:

curl -v https://local.broadinstitute.org:28443/

curl -v https://local.broadinstitute.org:28443/autocomplete?q=cancer

curl https://local.broadinstitute.org:28443/schemas/data-use | jq

curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ "generalUse": true }' 'https://local.broadinstitute.org:28443/schemas/data-use/consent/translate' | jq

curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ "generalUse": true }' 'https://local.broadinstitute.org:28443/schemas/data-use/dar/translate' | jq

curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ "purpose": { "type": "everything" }, "consent": { "type": "everything" } }' 'https://local.broadinstitute.org:28443/match' | jq

curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ "purpose": {"hmbResearch": true}, "dataset": {"generalUse": true} }' 'https://local.broadinstitute.org:28443/match/datause' | jq
 
curl -X GET --header 'Accept: application/json' 'https://local.broadinstitute.org:28443/search?id=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_602' | jq

curl https://local.broadinstitute.org:28443/status | jq

curl https://local.broadinstitute.org:28443/version | jq

curl -X POST --header 'Content-Type: application/json' --header 'Accept: text/plain' -d '{ "hmbResearch": true }' 'https://local.broadinstitute.org:28443/translate?for=dataset'

curl -X POST --header 'Content-Type: application/json' --header 'Accept: text/plain' -d '{ "hmbResearch": true }' 'https://local.broadinstitute.org:28443/translate?for=purpose'

curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ "type": "everything" }' 'https://local.broadinstitute.org:28443/validate/userestriction' | jq
```
