### PR TITLE
Turn down mock server logging

### DIFF
--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/WithMockServer.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/WithMockServer.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.dsde.consent.ontology;
+
+import org.mockserver.integration.ClientAndServer;
+
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+
+public interface WithMockServer {
+
+    default ClientAndServer startMockServer(int port) {
+        // Force mock server logging
+        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
+                .setLevel(ch.qos.logback.classic.Level.OFF);
+        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                .getLogger("org.mockserver"))
+                .setLevel(ch.qos.logback.classic.Level.OFF);
+        return startClientAndServer(port);
+    }
+
+}

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.consent.ontology.service;
 
+import org.broadinstitute.dsde.consent.ontology.WithMockServer;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
 import org.broadinstitute.dsde.consent.ontology.resources.model.TermResource;
 import org.junit.After;
@@ -20,13 +21,12 @@ import java.util.List;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpError.error;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 @SuppressWarnings("FieldCanBeLocal")
-public class ElasticSearchAutocompleteTest {
+public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     private ElasticSearchAutocomplete autocompleteAPI;
     private static final String INDEX_NAME = "local-ontology";
@@ -42,7 +42,7 @@ public class ElasticSearchAutocompleteTest {
         configuration.setIndex(INDEX_NAME);
         configuration.setServers(Collections.singletonList("localhost"));
         autocompleteAPI = new ElasticSearchAutocomplete(configuration);
-        server = startClientAndServer(9200);
+        server = startMockServer(9200);
     }
 
     @After

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.consent.ontology.service;
 
 import com.codahale.metrics.health.HealthCheck;
+import org.broadinstitute.dsde.consent.ontology.WithMockServer;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
 import org.junit.After;
 import org.junit.Before;
@@ -12,12 +13,11 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpError.error;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-public class ElasticSearchHealthCheckTest {
+public class ElasticSearchHealthCheckTest implements WithMockServer {
 
     private ElasticSearchHealthCheck elasticSearchHealthCheck;
     private ClientAndServer server;
@@ -28,7 +28,7 @@ public class ElasticSearchHealthCheckTest {
         configuration.setIndex("test-ontology");
         configuration.setServers(Collections.singletonList("localhost"));
         elasticSearchHealthCheck = new ElasticSearchHealthCheck(configuration);
-        server = startClientAndServer(9200);
+        server = startMockServer(9200);
     }
 
     @After


### PR DESCRIPTION
Turn off mock server logging so tests can run more legibly.