### PR TITLE
[DUOS-231] Algorithm Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,16 @@ A semi-automated management service for compliant secondary use of human genomic
 There are restrictions on researching human genomics data. For example: “Data can only be used for breast cancer research with non-commercial purpose”.
 The Data Use Oversight system ensures that researchers using genomics data honor these restrictions.
 
-See [consent-ontology/DEVNOTES.md](DEVNOTES.md) to run locally.
+## Matching Algorithms
+
+See [Algorithm](docs/Algorithms.md) and [Use Restriction Grammar](docs/UseRestrictionGrammar.md) for detailed information on how the system 
+peforms data use matching between consented datasets and research purposes.
+
+## Contributing
+
+See [Contributing](docs/CONTRIBUTING.md) for information on how to 
+contribute to this project. 
+
+## Local Development
+See [DEVNOTES.md](docs/DEVNOTES.md) to run locally.
+

--- a/docs/Algorithms.md
+++ b/docs/Algorithms.md
@@ -1,0 +1,60 @@
+# Matching Algorithm
+
+See the [Swagger](https://consent-ontology.dsde-prod.broadinstitute.org/#/) page for detailed usage
+of the Matching APIs. This document describes the different approaches to matching a Research Purpose
+and a Consent on a dataset. Both Purpose and Consent are structured objects which allows for computational
+matching at scale. 
+
+## Version 1
+The original version of the algorithm uses an ontology tree to match a purpose and consent. First, we 
+construct a composite ontology tree from:
+
+* [Human Disease Ontology](https://www.ebi.ac.uk/ols/ontologies/doid)
+* [Data Use Ontology](https://www.ebi.ac.uk/ols/ontologies/duo)
+* [Broad Data Use Ontology](https://github.com/DataBiosphere/consent-data-use/)
+
+Next, we create ontology nodes for the consent, the purpose and add them to the composite tree. Using 
+an [OWL](https://github.com/owlcs/owlapi) Reasoner, we determine if the purpose is a subclass of the 
+consent, or not. A valid ontological subclass for a research purpose indicates a successful match 
+between the purpose and the consent. See [Use Restriction Grammar](./UseRestrictionGrammar.md) for how
+we create ontology nodes for a consent or research purpose.
+
+## Version 2
+This version of the algorithm uses a custom set of business rules to match a research purpose and consent.
+This was developed for [FireCloud](https://api.firecloud.org/) and is the basis for the Data Catalog search ruleset. 
+This version makes use of [Consent Codes](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005772)
+as developed for the GA4GH as well as Disease Codes (**DS-X**) from the [Human Disease Ontology](https://www.ebi.ac.uk/ols/ontologies/doid).
+
+| If my Research Purpose has... | Related DUL question | I should see ... |
+| ----------------------------- | -------------------- | ---------------- |
+| Disease focused research | Future use is limited to research involving the following disease area(s) **DS** | Any dataset with **GRU**=true |
+| | | Any dataset with **HMB**=true  |
+| | | Any dataset tagged to this disease exactly |
+| | | Any dataset tagged to a DOID ontology **Parent** of **DS-X** |
+| | | |
+| Methods development/Validation study | Future use for methods research (analytic/software/technology development) outside the bounds of the other specified restrictions is prohibited **NMDS** | Any dataset with **GRU**=true |
+| | | Any dataset where **NMDS** is false |
+| | | Any dataset where **NMDS** is true AND **DS-X** match |
+| | | |
+| Control set | Future use as a control set for diseases other than those specified is prohibited **NCTRL** | Any dataset where **NCTRL** is false and is (**GRU** or **HMB**) |
+| | | Any **DS-X** match, if user specified a disease in the research purpose |
+| | | |
+| Aggregate analysis to understand variation in the general population | Future use of aggregate-level data for general research purposes is prohibited **NAGR** | Any dataset where **NAGR** is false and is (**GRU** or **HMB**) | 
+| | | |
+| Study population origins or ancestry | Future use is limited to research involving a specific population **POA** | Any dataset tagged with **GRU** |
+| | | |
+| Commercial purpose/by a commercial entity | Future commercial use is prohibited **NCU**. Future use by for-profit entities is prohibited **NPU** | Any dataset where **NPU** and **NCU** are both false |
+| | | |
+| Pediatric focused research | Future use is limited to pediatric research **RS-PD** | Any dataset tagged with **RS-PD** |
+| | | |
+| Gender focused research | Future use is limited to research involving a particular gender **RS-G** | Any dataset tagged with **RS-G:F** OR **N/A** when gender is **F** |
+| | | Any dataset tagged with **RS-G:M** OR **N/A**  when gender is **M** |
+| | | |
+
+
+
+
+
+
+
+

--- a/docs/Algorithms.md
+++ b/docs/Algorithms.md
@@ -50,11 +50,3 @@ as developed for the GA4GH as well as Disease Codes (**DS-X**) from the [Human D
 | Gender focused research | Future use is limited to research involving a particular gender **RS-G** | Any dataset tagged with **RS-G:F** OR **N/A** when gender is **F** |
 | | | Any dataset tagged with **RS-G:M** OR **N/A**  when gender is **M** |
 | | | |
-
-
-
-
-
-
-
-

--- a/docs/Algorithms.md
+++ b/docs/Algorithms.md
@@ -20,8 +20,11 @@ between the purpose and the consent. See [Use Restriction Grammar](./UseRestrict
 we create ontology nodes for a consent or research purpose.
 
 ## Version 2
-This version of the algorithm uses a custom set of business rules to match a research purpose and consent.
-This was developed for [FireCloud](https://api.firecloud.org/) and is the basis for the Data Catalog search ruleset. 
+This version of the algorithm uses a custom set of business rules to match a research purpose and consented dataset. 
+In determining a postive match between research purpose and consented dataset, we make sure that the consented
+dataset matches **ALL** conditions specified in the research purpose.  
+
+This was originally developed for [FireCloud](https://api.firecloud.org/) and is the basis for the Data Catalog search ruleset. 
 This version makes use of [Consent Codes](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005772)
 as developed for the GA4GH as well as Disease Codes (**DS-X**) from the [Human Disease Ontology](https://www.ebi.ac.uk/ols/ontologies/doid).
 
@@ -29,6 +32,10 @@ as developed for the GA4GH as well as Disease Codes (**DS-X**) from the [Human D
 | ----------------------------- | -------------------- | ---------------- |
 | Disease focused research | Future use is limited to research involving the following disease area(s) **DS** | Any dataset with **GRU**=true |
 | | | Any dataset with **HMB**=true  |
+| | | Any dataset tagged to this disease exactly |
+| | | Any dataset tagged to a DOID ontology **Parent** of **DS-X** |
+| | | |
+| Health, Medical, Biological focused research | Future use is limited to **HMB** research | Any dataset with **HMB**=true |
 | | | Any dataset tagged to this disease exactly |
 | | | Any dataset tagged to a DOID ontology **Parent** of **DS-X** |
 | | | |

--- a/docs/Algorithms.md
+++ b/docs/Algorithms.md
@@ -28,32 +28,127 @@ This was originally developed for [FireCloud](https://api.firecloud.org/) and is
 This version makes use of [Consent Codes](https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005772)
 as developed for the GA4GH as well as Disease Codes (**DS-X**) from the [Human Disease Ontology](https://www.ebi.ac.uk/ols/ontologies/doid).
 
-| If my Research Purpose has... | Related DUL question | I should see ... |
-| ----------------------------- | -------------------- | ---------------- |
-| Disease focused research | Future use is limited to research involving the following disease area(s) **DS** | Any dataset with **GRU**=true |
-| | | Any dataset with **HMB**=true  |
-| | | Any dataset tagged to this disease exactly |
-| | | Any dataset tagged to a DOID ontology **Parent** of **DS-X** |
-| | | |
-| Health, Medical, Biological focused research | Future use is limited to **HMB** research | Any dataset with **HMB**=true |
-| | | Any dataset tagged to this disease exactly |
-| | | Any dataset tagged to a DOID ontology **Parent** of **DS-X** |
-| | | |
-| Methods development/Validation study | Future use for methods research (analytic/software/technology development) outside the bounds of the other specified restrictions is prohibited **NMDS** | Any dataset with **GRU**=true |
-| | | Any dataset where **NMDS** is false |
-| | | Any dataset where **NMDS** is true AND **DS-X** match |
-| | | |
-| Control set | Future use as a control set for diseases other than those specified is prohibited **NCTRL** | Any dataset where **NCTRL** is false and is (**GRU** or **HMB**) |
-| | | Any **DS-X** match, if user specified a disease in the research purpose |
-| | | |
-| Aggregate analysis to understand variation in the general population | Future use of aggregate-level data for general research purposes is prohibited **NAGR** | Any dataset where **NAGR** is false and is (**GRU** or **HMB**) | 
-| | | |
-| Study population origins or ancestry | Future use is limited to research involving a specific population **POA** | Any dataset tagged with **GRU** |
-| | | |
-| Commercial purpose/by a commercial entity | Future commercial use is prohibited **NCU**. Future use by for-profit entities is prohibited **NPU** | Any dataset where **NPU** and **NCU** are both false |
-| | | |
-| Pediatric focused research | Future use is limited to pediatric research **RS-PD** | Any dataset tagged with **RS-PD** |
-| | | |
-| Gender focused research | Future use is limited to research involving a particular gender **RS-G** | Any dataset tagged with **RS-G:F** OR **N/A** when gender is **F** |
-| | | Any dataset tagged with **RS-G:M** OR **N/A**  when gender is **M** |
-| | | |
+<table>
+	<thead>
+		<tr>
+			<th>If my Research Purpose has...</th>
+			<th>What datasets should I see?</th>
+			<th>Related DUL question</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Disease focused research (i.e. <strong>DS-X</strong>)</td>
+			<td>
+				<ul>
+					<li>Any dataset with <strong>GRU</strong>=true</li>
+					<li>Any dataset with <strong>HMB</strong>=true</li>
+					<li>Any dataset tagged to this disease (<strong>DS-X</strong>) exactly or a parent disease of <strong>DS-X</strong></li>
+				</ul>	
+			</td>	
+			<td>
+				<ul>
+					<li>Data is available for future general research use</li>
+					<li>Future use is limited for health/medical/biomedical research</li>
+					<li>Future use is limited to research involving the following disease area(s) <strong>DS-X</strong></li>					
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>Methods development/Validation study</td>
+			<td>
+				<ul>
+					<li>Any dataset with <strong>GRU</strong>=true</li>
+					<li>Any dataset where <strong>NMDS</strong> is false</li>
+					<li>Any dataset where <strong>NMDS</strong> is true AND <strong>DS-X</strong> match</li>
+				</ul>	
+			</td>	
+			<td>
+				<ul>
+					<li>Future use for methods research (analytic/software/technology development) outside the bounds of the other specified restrictions is prohibited <strong>NMDS</strong></li>
+				</ul>						
+			</td>
+		</tr>
+		<tr>
+			<td>Control Set</td>
+			<td>
+				<ul>
+					<li>Any dataset where <strong>NCTRL</strong> is false and is (<strong>GRU</strong> or <strong>HMB</strong>)</li>
+					<li>Any <strong>DS-X</strong> match, if user specified a disease in the research purpose</li>
+				</ul>	
+			</td>	
+			<td>
+				<ul>
+					<li>Future use as a control set for diseases other than those specified is prohibited <strong>NCTRL</strong></li>
+					<li>Future use is limited to research involving the following disease area(s) <strong>DS-X</strong></li>
+				</ul>	
+			</td>
+		</tr>
+		<tr>
+			<td>Aggregate analysis to understand variation in the general population</td>
+			<td>
+				<ul>
+					<li>Any dataset where <strong>NAGR</strong> is false and is (<strong>GRU</strong> or <strong>HMB</strong>)</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Future use of aggregate-level data for general research purposes is prohibited <strong>NAGR</strong></li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>Study population origins or ancestry</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong>GRU</strong></li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Future use is limited to research involving a specific population POA</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>Commercial purpose/by a commercial entity</td>
+			<td>
+				<ul>
+					<li>Any dataset where <strong>NPU</strong> and <strong>NCU</strong> are both false</li>
+				</ul>			
+			</td>
+			<td>
+				<ul>
+					<li>Future commercial use is prohibited <strong>NCU</strong>. Future use by for-profit entities is prohibited <strong>NPU</strong></li>
+				</ul>			
+			</td>
+		</tr>
+		<tr>
+			<td>Pediatric focused research</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong>RS-PD</strong></li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Future use is limited to pediatric research <strong>RS-PD</strong></li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>Gender focused research</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong><strong>RS-G</strong>:F</strong> OR N/A when gender is F</li>
+					<li>Any dataset tagged with <strong><strong>RS-G</strong>:M</strong> OR N/A when gender is M</li>
+				</ul>			
+			</td>
+			<td>
+				<ul>
+					<li>Future use is limited to research involving a particular gender <strong>RS-G</strong></li>
+				</ul>
+			</td>
+		</tr>	
+	</tbody>
+</table>

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 You most likely want to do your work on a feature branch based on develop. There is no explicit naming convention; we usually use some combination of the JIRA issue number and something alluding to the work we're doing.
 
-When you open a pull request, add the JIRA issue number (e.g. `BTRX-1234`) to the PR title. This will make a reference from JIRA to the GitHub issue. Add a brief description of your changes above the PR checkbox template.
+When you open a pull request, add the JIRA issue number (e.g. `DUOS-1234`) to the PR title. This will make a reference from JIRA to the GitHub issue. Add a brief description of your changes above the PR checkbox template.
 
 This is also a good opportunity to check that the acceptance criteria for your JIRA ticket exists and is met. Check with your PO if you have any questions there. You should also fill out a summary to go in the release notes and some instructions on what QA should be looking at.
 
@@ -18,9 +18,8 @@ You should get review from two people (either through GitHub's request-review fe
 
 Your PR is ready to merge when all of the following things are true:
 
-1. Two reviewers have thumbed (or otherwise approved) your PR
-2. If your change is user-facing, your PO has seen it and signed off
-3. All tests pass
+1. At least one reviewer has thumbed (or otherwise approved) your PR
+2. All tests pass
 
 ## API changes
 
@@ -37,7 +36,3 @@ If you're making breaking changes to the API, do the following:
 1. Check in with Comms to explain the change and the impact on users.
 2. Write an email to users explaining the change and send it least a few days BEFORE the release goes out. You'll need to explain the change and what users need to do to update their code. Get Comms signoff on the wording.
 3. Get someone Suitable to send the email to api-users@firecloud.org.
-
-## FISMA documentation changes
-
-If you're making changes to authentication, authorization, encryption, or audit trails, you should check in with Bernick or Jyotin to see if our security documentation should be updated.

--- a/docs/DEVNOTES.md
+++ b/docs/DEVNOTES.md
@@ -21,7 +21,7 @@ Ensure that your test environment supports that.
 
 #### Docker
 
-Consent-Ontology is packaged into a docker image that is stored in the cloud in the [Consent-Ontology Dockerhub Repo](https://hub.docker.com/r/broadinstitute/consent-ontology).
+Consent-Ontology is packaged into a docker image that is stored in [Consent-Ontology Dockerhub Repo](https://hub.docker.com/r/broadinstitute/consent-ontology).
 ```
 # to build the image
 ./build.sh -d build

--- a/docs/UseRestrictionGrammar.md
+++ b/docs/UseRestrictionGrammar.md
@@ -1,0 +1,123 @@
+# Use Restriction Grammar
+
+A Consent or Research Purpose is a rendering of an OWL class, into JSON, 
+using the following grammar:
+
+```
+Consent := {
+  "restriction": UseRestriction
+}
+ 
+ResearchPurpose := {
+  "restriction": UseRestriction
+}
+```
+
+A use restriction expression represents a consent attached to a single sample 
+or collection of samples or a research purpose. The "restriction" field 
+contains the structured use restriction.
+
+```
+UseRestriction := 
+    OrExpression
+  | AndExpression
+  | NotExpression
+  | NamedExpression
+  | EverythingExpression
+  | NothingExpression
+
+OrExpression := { 
+  "type": "or", 
+  "operands": [ UseRestriction* ]
+}
+
+AndExpression := { 
+  "type": "and", 
+  "operands": [ UseRestriction* ]
+}
+
+NotExpression := { 
+  "type": "not", 
+  "operand": UseRestriction
+}
+
+NamedExpression := { 
+  "type": "named", 
+  "name": <string>
+}
+
+EverythingExpression := { 
+  "type": "everything"
+}
+
+NothingExpression := { 
+  "type": "nothing"
+}
+```
+
+## Common Examples
+
+### Named Conditions
+Intermediate forms of use restriction are usually represented using the 
+NamedExpression and the boolean operators (And, Or, Not). For example, 
+a sample which was only available for use in cancer research might be 
+annotated with the expression:
+
+```
+// Consent restriction only for Cancer
+{
+  "restriction": {
+    "type": "named",
+    "name": "http://purl.obolibrary.org/obo/DOID_162"
+  }
+}
+```
+
+### Or Conditions
+
+If a study were restricted to cancer (DOID:162) OR heart disease (DOID:114), 
+we could represent that with the following expression:
+
+```
+// Consent restriction for Cancer OR Heart Disease
+{
+  "restriction": {
+    "type": "or",
+    "operands": [ 
+      {
+        "type": "named",
+        "name": "http://purl.obolibrary.org/obo/DOID_162"
+      },
+      {
+        "type": "named",
+        "name": "http://purl.obolibrary.org/obo/DOID_114"
+      }
+    ]
+  }
+}
+```
+
+### And Conditions
+And conditions typically incorporate different categories of information. 
+Studies that restrict data usage only to research for pediatric cancer 
+are a good example of that. Such an expression might be expressed this way:
+
+```
+// Consent restriction for Pediatric Cancer
+{
+  "restriction": {
+    "type": "and",
+    "operands": [ 
+      {
+        "type": "named",
+        "name": "http://purl.obolibrary.org/obo/DOID_162"
+      },
+      {
+        "type": "named",
+        "name": "http://www.broadinstitute.org/ontologies/DUOS/pediatric"
+      }
+    ]
+  }
+}
+```
+

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
@@ -29,7 +29,7 @@ class DataUseMatchCases {
      *      Any dataset tagged with GRU
      *      Any dataset tagged with HMB
      *      *** Adding based on HMB Truth Table use case support ***
-     *      TODO: Validate that this is acceptable with Product Owner. See https://broadinstitute.atlassian.net/browse/BTRX-481
+     *      TODO: Validate that this is acceptable with Product Owner. See See https://broadinstitute.atlassian.net/browse/DUOS-259
      *      Any DS match
      */
     static boolean matchHMB(DataUse purpose, DataUse dataset, boolean diseaseMatch) {

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
@@ -209,8 +209,8 @@ class DataUseMatchCases {
     }
 
     /**
-     * TODO: Validate that this is acceptable with Product Owner. See https://broadinstitute.atlassian.net/browse/BTRX-481
-     * RP: Restricted to a pediatric
+     * TODO: Validate that this is acceptable with Product Owner. See https://broadinstitute.atlassian.net/browse/DUOS-259
+     * RP: Restricted to pediatric
      * Future use is limited to pediatric research [RS-PD] (required) (Yes | No)
      * Datasets:
      *      Any dataset tagged with RS-PD
@@ -230,7 +230,7 @@ class DataUseMatchCases {
     }
 
     /**
-     * TODO: Validate that this is acceptable with Product Owner. See https://broadinstitute.atlassian.net/browse/BTRX-481
+     * TODO: Validate that this is acceptable with Product Owner. See https://broadinstitute.atlassian.net/browse/DUOS-259
      * RP: Restricted to a gender
      * Women
      * Men

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseMatchPair.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseMatchPair.java
@@ -7,13 +7,13 @@ public class DataUseMatchPair {
 
     private DataUse purpose;
 
-    private DataUse dataset;
+    private DataUse consent;
 
     public DataUseMatchPair() { }
 
-    public DataUseMatchPair(DataUse purpose, DataUse dataset) {
+    public DataUseMatchPair(DataUse purpose, DataUse consent) {
         this.purpose = purpose;
-        this.dataset = dataset;
+        this.consent = consent;
     }
 
     public DataUse getPurpose() {
@@ -24,12 +24,12 @@ public class DataUseMatchPair {
         this.purpose = purpose;
     }
 
-    public DataUse getDataset() {
-        return dataset;
+    public DataUse getConsent() {
+        return consent;
     }
 
-    public void setDataset(DataUse dataset) {
-        this.dataset = dataset;
+    public void setConsent(DataUse consent) {
+        this.consent = consent;
     }
 
     @Override

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -74,7 +74,7 @@ paths:
         - text/plain
       parameters:
         - name: for
-          in: query
+          in: body
           description: dataset or purpose
           required: true
           schema:
@@ -109,15 +109,38 @@ paths:
       tags:
         - Match
       responses:
-        '200':
-          description: Successful matching.
-        default:
-          description: Unexpected error
+        200:
+          description: Match Result.
+          schema:
+            $ref: '#/definitions/MatchPairResult'
+        500:
+          description: Internal Server Error
           
-  /match/datause:
+  /match/v1:
     post:
-      summary: Match DataUse Purpose and Dataset
-      description: Determine if a Research Purpose and Dataset logically match.
+      summary: Match UseRestriction Consent and Research Purpose
+      description: The Match service will render a response of true or false between a Consent and a Research Purpose.
+      parameters:
+        - name: body
+          in: body
+          description: Consent and Purpose Use Restrictions.
+          required: true
+          schema:
+            $ref: '#/definitions/MatchPair'
+      tags:
+        - Match
+      responses:
+        200:
+          description: Match Result.
+          schema:
+            $ref: '#/definitions/MatchPairResult'
+        500:
+          description: Internal Server Error
+
+  /match/v2:
+    post:
+      summary: Match DataUse Purpose and Consent
+      description: Determine if a Research Purpose and Consent logically match.
       parameters:
         - name: body
           in: body
@@ -133,7 +156,7 @@ paths:
           schema:
             $ref: '#/definitions/DataUseMatchPairResult'
         400:
-          description: Bad Request if either purpose or dataset are not provided.
+          description: Bad Request if either purpose or consent are not provided.
         500:
           description: Internal Server Error
 
@@ -151,7 +174,7 @@ paths:
         tags:
           - Validate
         responses:
-          '200':
+          200:
             description: Successful validation. True for valid restriction and False for invalid.
           default:
             description: Unexpected error
@@ -179,7 +202,7 @@ paths:
       tags:
         - Autocomplete
       responses:
-        '200':
+        200:
           description: Array of results.
         default:
           description: Unexpected error
@@ -197,11 +220,11 @@ paths:
       tags:
         - Search
       responses:
-        '200':
+        200:
           description: The given id was found. Term result with parent information.
-        '400':
+        400:
           description: Bad request.
-        '404':
+        404:
           description: The given id was not found.
         default:
           description: Unexpected error
@@ -213,8 +236,10 @@ paths:
       tags:
         - Status
       responses:
-        200: All systems are OK
-        500: Some number of subsystems are not OK.
+        200:
+          description: All systems are OK
+        500:
+          description: Some number of subsystems are not OK.
 
   /version:
     get:
@@ -227,7 +252,8 @@ paths:
           description: Successful Response
           schema:
             $ref: '#/definitions/Version'
-        500: Internal Server Error
+        500:
+          description: Internal Server Error
 
 definitions:
   Restriction:
@@ -267,20 +293,20 @@ definitions:
             items:
               type: string
               description: Array of ontologies.
+
+  MatchPairResult:
+    type: object
+    properties:
+      result:
+        type: boolean
+      matchPair:
+        $ref: '#/definitions/MatchPair'
+
   DataUse:
     type: object
     description: JSON model of a set of data use questions and answers
-    example: |
-      {
-        "generalUse": false,
-        "hmbResearch": true,
-        "diseaseRestrictions": ["http://purl.obolibrary.org/obo/DOID_602", "http://purl.obolibrary.org/obo/DOID_162"],
-        "gender": "Male",
-        ...
-        additional JSON-standard fields as
-        defined by the Data Use schema
-        ...
-      }
+    example:
+      { "generalUse": false, "hmbResearch": true, "diseaseRestrictions": ["http://purl.obolibrary.org/obo/DOID_602"] }
 
   DataUseMatchPair:
     type: object
@@ -288,7 +314,7 @@ definitions:
     properties:
       purpose:
         $ref: '#/definitions/DataUse'
-      dataset:
+      consent:
         $ref: '#/definitions/DataUse'
 
   DataUseMatchPairResult:


### PR DESCRIPTION
## Addresses 
See https://broadinstitute.atlassian.net/browse/DUOS-231

## Changes
* Lots of swagger yaml updates to fix some consistency issues
* Add a `match/v1` endpoint that calls the original match method
* Move the `match/dataUse` matching endpoint (currently not in use) to `match/v2`
* Docs for the two algorithms we have now. For V2, there is a [google doc here](https://docs.google.com/document/d/1P70Gt5wCru0YzvJWNru9Nt4tCADhEsBWpKPp7qs_n2M) that describes the business rules developed for FireCloud implementation. Our implementation of the rule set is a bit more expansive than what's covered there. We handle gender and pediatric conditions where FC does not. 
* Docs for use restriction grammar. This is [originally here](https://broadinstitute.atlassian.net/wiki/spaces/DSDEV/pages/8323107/Consent+and+Use+Restriction+Grammar) but that version is very out of date. I have made some small edits and pruned it a bit.
* Consolidated docs to a docs directory.

The algorithm readme looks something like this PDF export: [Algorithms.pdf](https://github.com/DataBiosphere/consent-ontology/files/3048007/Algorithms.pdf)

The use restriction grammar readme looks something like this PDF export: [UseRestrictionGrammar.pdf](https://github.com/DataBiosphere/consent-ontology/files/3039648/UseRestrictionGrammar.pdf)
