### PR TITLE
Update Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <dropwizard.version>1.3.7</dropwizard.version>
         <metrics.version>4.0.3</metrics.version>
         <akka.version>2.4.20</akka.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <jersey.version>2.19</jersey.version>
         <swagger.ui.version>2.2.8</swagger.ui.version>
         <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>


### PR DESCRIPTION
Update jackson based on latest security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2019-12086