### PR TITLE
[DUOS-368][risk=no] Remove unnecessary empty path

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
@@ -55,7 +55,6 @@ public class SwaggerResource {
     UriInfo uriInfo;
 
     @GET
-    @Path("")
     public Response main() {
         return content("");
     }


### PR DESCRIPTION
Addresses https://broadinstitute.atlassian.net/browse/DUOS-368

Fixes a sentry warning message, example here: https://sentry.io/organizations/broad-institute/issues/964180435

See also https://github.com/DataBiosphere/consent/pull/342