### PR TITLE
[DUOS-331][risk=no] Add failure reasons to the V2 match logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
   - mvn clean verify
 after_success:

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
@@ -29,6 +29,7 @@ class DataUseMatchCases {
     private static final String DS_F2 = "The Disease-Specific: %s Research Purpose is not a valid subclass of the Disease-Specific data use limitations.";
     private static final String NMDS_F1 = "The Methods development Research Purpose is prohibited by the NMDS No Methods Development data use limitation.";
     private static final String NCTRL_F1 = "The Controls Use Research Purpose is prohibited by the NCTRL No Controls Use data use limitation.";
+    private static final String NCTRL_F2 = "TThe Disease-Specific: %s Research Purpose is not a valid subclass of the Disease-Specific data use limitations.";
     private static final String NAGR_F1 = "The Aggregate-level Research Purpose is prohibited by the NAGR No Aggregate-level data use limitation.";
     private static final String POA_F1 = "The Populations, Origins, Ancestry Research Purpose does not match the HMB or Disease-Specific data use limitation.";
     private static final String NCU_F1 = "The Commercial Use Research Purpose does not match the No Commerical Use data use limitation.";
@@ -147,10 +148,9 @@ class DataUseMatchCases {
         if (datasetNMDS && diseaseMatch) {
             return ImmutablePair.of(true, Collections.emptyList());
         } else {
-            failures.add(NMDS_F1);
+            // If there is a disease failure, that will already be captured in the disease match block
+            return ImmutablePair.of(false, failures);
         }
-
-        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
@@ -178,10 +178,9 @@ class DataUseMatchCases {
         if (!purpose.getDiseaseRestrictions().isEmpty() && diseaseMatch) {
             return ImmutablePair.of(true, Collections.emptyList());
         } else {
-            failures.add(NCTRL_F1);
+            // If there is a disease failure, that will already be captured in the disease match block
+            return ImmutablePair.of(false, failures);
         }
-
-        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
@@ -248,11 +247,6 @@ class DataUseMatchCases {
         boolean datasetCommercial = getNullableOrFalse(dataset.getCommercialUse());
 
         if (purposeCommercial && !datasetCommercial) {
-            failures.add(NCU_F1);
-        }
-
-        // TODO: Fix this ... it's wrong.
-        if (!purposeCommercial && datasetCommercial) {
             failures.add(NCU_F1);
         }
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCases.java
@@ -1,12 +1,13 @@
 package org.broadinstitute.dsde.consent.ontology.datause;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.broadinstitute.dsde.consent.ontology.resources.model.DataUse;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * General case is that we make very granular comparisons.
@@ -16,7 +17,7 @@ import java.util.stream.Collectors;
  * Prefer longer, descriptive expressions over terse comparisons. We're not looking for
  * the most concise code possible, but instead favor clarity.
  */
-@SuppressWarnings({"RedundantIfStatement", "ConstantConditions"})
+@SuppressWarnings({"ConstantConditions"})
 class DataUseMatchCases {
 
     private static final String na = "N/A";
@@ -28,14 +29,16 @@ class DataUseMatchCases {
      * Datasets:
      *      Any dataset tagged with GRU
      *      Any dataset tagged with HMB
-     *      *** Adding based on HMB Truth Table use case support ***
-     *      TODO: Validate that this is acceptable with Product Owner. See See https://broadinstitute.atlassian.net/browse/DUOS-259
      *      Any DS match
+     *
+     * @param purpose The data use object representing the Research Purpose
+     * @param dataset The data use object representing the Dataset
+     * @param diseaseMatch Indicator for a pre-existing disease match
      */
-    static boolean matchHMB(DataUse purpose, DataUse dataset, boolean diseaseMatch) {
+    static ImmutablePair<Boolean, List<String>> matchHMB(DataUse purpose, DataUse dataset, boolean diseaseMatch) {
         // short-circuit hmb if not set
         if (purpose.getHmbResearch() == null && dataset.getHmbResearch() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
         boolean purposeGRU = getNullableOrFalse(purpose.getGeneralUse());
@@ -44,21 +47,22 @@ class DataUseMatchCases {
         boolean datasetHMB = getNullableOrFalse(dataset.getHmbResearch());
 
         if (datasetHMB && purposeGRU) {
-            return false;
+            return ImmutablePair.of(false, Collections.singletonList("[HMB] Research Purpose requires a General Use Dataset"));
         }
 
         if (purposeHMB && datasetGRU) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
         if (purposeHMB && datasetHMB) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
         if (diseaseMatch) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
+        } else {
+            return ImmutablePair.of(false, Collections.singletonList("[HMB] Research Purpose does not match the disease restriction for the Dataset"));
         }
 
-        return false;
     }
 
     /**
@@ -69,34 +73,41 @@ class DataUseMatchCases {
      *      Any dataset with HMB=true
      *      Any dataset tagged to this disease exactly
      *      Any dataset tagged to a DOID ontology Parent of disease X
+     *
+     * @param purpose The data use object representing the Research Purpose
+     * @param dataset The data use object representing the Dataset
+     * @param purposeDiseaseIdMap is a map of each purpose term id to a list of that term's parent term ids
      */
-    static boolean matchDiseases(DataUse purpose, DataUse dataset, Map<String, List<String>> purposeDiseaseIdMap) {
+    static ImmutablePair<Boolean, List<String>> matchDiseases(DataUse purpose, DataUse dataset, Map<String, List<String>> purposeDiseaseIdMap) {
         // short-circuit if no disease focused research
         if (purpose.getDiseaseRestrictions().isEmpty() && dataset.getDiseaseRestrictions().isEmpty()) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
         // short-circuit if dataset is GRU
         if (getNullableOrFalse(dataset.getGeneralUse())) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
         // short-circuit if dataset is HMB
         if (getNullableOrFalse(dataset.getHmbResearch())) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
         // short-circuit if no diseases specified in the purpose, but the dataset specifies diseases
         if (!dataset.getDiseaseRestrictions().isEmpty() && purpose.getDiseaseRestrictions().isEmpty()) {
-            return false;
+            return ImmutablePair.of(false, Collections.singletonList("[DS:X] Dataset has disease restrictions while the research purpose does not"));
         }
 
         // We want all purpose disease IDs to be a subclass of any dataset disease ID
-        Set<Boolean> matches = purposeDiseaseIdMap
-                .values()
-                .stream()
-                .map(idList -> idList
-                        .stream()
-                        .anyMatch(dataset.getDiseaseRestrictions()::contains))
-                .collect(Collectors.toSet());
-        return !matches.contains(false);
+        List<String> failures = new ArrayList<>();
+        for (Map.Entry<String, List<String>> entry : purposeDiseaseIdMap.entrySet()) {
+            boolean match = entry.getValue()
+                    .stream()
+                    .anyMatch(dataset.getDiseaseRestrictions()::contains);
+            if (!match) {
+                failures.add("[DS:X] Research Purpose Disease term " + entry.getKey() + " is not a valid subclass of any dataset disease restrictions.");
+            }
+        }
+
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
@@ -107,22 +118,27 @@ class DataUseMatchCases {
      *      Any dataset where NMDS is false
      *      Any dataset where NMDS is true AND DS-X match
      */
-    static boolean matchNMDS(DataUse purpose, DataUse dataset, boolean diseaseMatch) {
+    static ImmutablePair<Boolean, List<String>> matchNMDS(DataUse purpose, DataUse dataset, boolean diseaseMatch) {
         // short-circuit if no nmds clause
         if (purpose.getMethodsResearch() == null && dataset.getMethodsResearch() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
+        List<String> failures = new ArrayList<>();
         boolean datasetNMDS = getNullableOrFalse(dataset.getMethodsResearch());
         if (!datasetNMDS) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
+        } else {
+            failures.add("[NMDS] Dataset is restricted to no method development research");
         }
 
         if (datasetNMDS && diseaseMatch) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
+        } else {
+            failures.add("[NMDS] Research Purpose does not match the disease restriction for the Dataset");
         }
 
-        return false;
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
@@ -132,23 +148,28 @@ class DataUseMatchCases {
      *      Any dataset where NCTRL is false and is (GRU or HMB)
      *      Any DS-X match, if user specified a disease in the res purpose search
      */
-    static boolean matchControlSet(DataUse purpose, DataUse dataset, boolean diseaseMatch) {
+    static ImmutablePair<Boolean, List<String>> matchControlSet(DataUse purpose, DataUse dataset, boolean diseaseMatch) {
         // short-circuit if no control set clause
         if (purpose.getControlSetOption() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
+        List<String> failures = new ArrayList<>();
         boolean datasetNCTRL = getNullable(purpose.getControlSetOption());
         boolean datasetGRUorHMB = (getNullableOrFalse(dataset.getGeneralUse()) || getNullableOrFalse(dataset.getHmbResearch()));
         if (datasetNCTRL && datasetGRUorHMB) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
+        } else {
+            failures.add("[NCTRL] Dataset is restricted to no control set usage");
         }
 
         if (!purpose.getDiseaseRestrictions().isEmpty() && diseaseMatch) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
+        } else {
+            failures.add("[NCTRL] Research Purpose does not match the disease restriction for the Dataset");
         }
 
-        return false;
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
@@ -157,18 +178,23 @@ class DataUseMatchCases {
      * Datasets:
      *      Any dataset where NAGR is false and is (GRU or HMB)
      */
-    static boolean matchNAGR(DataUse purpose, DataUse dataset) {
+    static ImmutablePair<Boolean, List<String>> matchNAGR(DataUse purpose, DataUse dataset) {
         // short-circuit if no aggregate clause
         if (purpose.getAggregateResearch() == null && dataset.getAggregateResearch() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
+        List<String> failures = new ArrayList<>();
         boolean purposeNAGR = getNullable(purpose.getAggregateResearch());
         boolean datasetNAGR = getNullable(dataset.getAggregateResearch());
 
-        return purposeNAGR &&
+        if (!(purposeNAGR &&
                 !datasetNAGR &&
-                (getNullableOrFalse(dataset.getHmbResearch()) || getNullableOrFalse(dataset.getGeneralUse()));
+                (getNullableOrFalse(dataset.getHmbResearch()) || getNullableOrFalse(dataset.getGeneralUse())))) {
+            failures.add("[NAGR] Future use of aggregate-level data for dataset is prohibited");
+        }
+
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
@@ -177,14 +203,19 @@ class DataUseMatchCases {
      * Datasets:
      *      Any dataset tagged with GRU
      */
-    static boolean matchPOA(DataUse purpose, DataUse dataset) {
+    static ImmutablePair<Boolean, List<String>> matchPOA(DataUse purpose, DataUse dataset) {
         // short-circuit if no POA clause
         if (purpose.getPopulationOriginsAncestry() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
-        return purpose.getPopulationOriginsAncestry() &&
-                getNullableOrFalse(dataset.getGeneralUse());
+        List<String> failures = new ArrayList<>();
+        if (!(purpose.getPopulationOriginsAncestry() &&
+                getNullableOrFalse(dataset.getGeneralUse()))) {
+            failures.add("[POA] Future use of aggregate-level data for general research purposes is prohibited");
+        }
+
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
@@ -194,49 +225,53 @@ class DataUseMatchCases {
      * Datasets:
      *      Any dataset where NPU and NCU are both false
      */
-    static boolean matchCommercial(DataUse purpose, DataUse dataset) {
+    static ImmutablePair<Boolean, List<String>> matchCommercial(DataUse purpose, DataUse dataset) {
         // short-circuit if no commercial clause
         if (purpose.getCommercialUse() == null || dataset.getCommercialUse() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
+        List<String> failures = new ArrayList<>();
         boolean purposeCommercial = getNullableOrFalse(purpose.getCommercialUse());
         boolean datasetCommercial = getNullableOrFalse(dataset.getCommercialUse());
 
-        if (purposeCommercial) {
-            return datasetCommercial;
+        if (purposeCommercial && !datasetCommercial) {
+            failures.add("[NCU/NPU] Dataset is not consented for commercial use");
         }
 
-        if (!purposeCommercial) {
-            return !datasetCommercial;
+        if (!purposeCommercial && datasetCommercial) {
+            failures.add("[NCU/NPU] Research Purpose is not consented for commercial use");
         }
 
-        return false;
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
-     * TODO: Validate that this is acceptable with Product Owner. See https://broadinstitute.atlassian.net/browse/DUOS-259
      * RP: Restricted to pediatric
      * Future use is limited to pediatric research [RS-PD] (required) (Yes | No)
      * Datasets:
      *      Any dataset tagged with RS-PD
      */
-    static boolean matchRSPD(DataUse purpose, DataUse dataset) {
+    static ImmutablePair<Boolean, List<String>> matchRSPD(DataUse purpose, DataUse dataset) {
         // short-circuit if dataset is not restricted
         if (dataset.getPediatric() == null || !dataset.getPediatric()) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
         // also short circuit if RS is not tagged:
         if (purpose.getPediatric() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
-        return purpose.getPediatric() && dataset.getPediatric();
+        List<String> failures = new ArrayList<>();
+        if (!(purpose.getPediatric() && dataset.getPediatric())) {
+            failures.add("[RS-PD] Research Purpose and Dataset Pediatric conditions do not align");
+        }
+
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     /**
-     * TODO: Validate that this is acceptable with Product Owner. See https://broadinstitute.atlassian.net/browse/DUOS-259
      * RP: Restricted to a gender
      * Women
      * Men
@@ -246,27 +281,32 @@ class DataUseMatchCases {
      *      RS-G:F or N/A
      *      RS-G:M or N/A
      */
-    static boolean matchRSG(DataUse purpose, DataUse dataset) {
+    static ImmutablePair<Boolean, List<String>> matchRSG(DataUse purpose, DataUse dataset) {
         // short-circuit if dataset is not restricted
         if (dataset.getGender() == null) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
         String purposeGender = Optional.ofNullable(purpose.getGender()).orElse(na);
 
         if (dataset.getGender().equalsIgnoreCase(na)) {
-            return true;
+            return ImmutablePair.of(true, Collections.emptyList());
         }
 
+        List<String> failures = new ArrayList<>();
         if (purposeGender.equalsIgnoreCase(male)) {
-            return dataset.getGender().equalsIgnoreCase(male);
+            if (!dataset.getGender().equalsIgnoreCase(male)) {
+                failures.add("[RS-G] Dataset restricted to research involving female participants");
+            }
         }
 
         if (purposeGender.equalsIgnoreCase(female)) {
-            return dataset.getGender().equalsIgnoreCase(female);
+            if (!dataset.getGender().equalsIgnoreCase(female)) {
+                failures.add("[RS-G] Dataset restricted to research involving male participants");
+            }
         }
 
-        return false;
+        return ImmutablePair.of(failures.isEmpty(), failures);
     }
 
     // Helper Methods

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcher.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcher.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.consent.ontology.datause;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.log4j.Logger;
@@ -10,12 +9,10 @@ import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -77,8 +74,8 @@ public class DataUseMatcher {
                 genderMatch.getLeft();
 
         List<String> reasons = Stream.of(
-                diseaseMatch.getRight(),
                 hmbMatch.getRight(),
+                diseaseMatch.getRight(),
                 nmdsMatch.getRight(),
                 controlMatch.getRight(),
                 nagrMatch.getRight(),

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/MatchResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/MatchResource.java
@@ -8,6 +8,7 @@ import akka.pattern.Patterns;
 import akka.util.Timeout;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.log4j.Logger;
 import org.broadinstitute.dsde.consent.ontology.Utils;
 import org.broadinstitute.dsde.consent.ontology.actor.MatchWorkerActor;
@@ -30,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URL;
 import java.util.Collection;
+import java.util.List;
 
 @Path("/match")
 @Consumes("application/json")
@@ -58,10 +60,15 @@ public class MatchResource {
         DataUse dataset = matchPair.getConsent();
         try {
             if (purpose != null && dataset != null) {
-                boolean match = dataUseMatcher.matchPurposeAndDataset(purpose, dataset);
+                ImmutablePair<Boolean, List<String>> matchResult = dataUseMatcher.matchPurposeAndDatasetV2(purpose, dataset);
+                boolean match = matchResult.getLeft();
+                List<String> failures = matchResult.getRight();
                 return Response
                         .ok()
-                        .entity(ImmutableMap.of("result", match, "matchPair", matchPair))
+                        .entity(ImmutableMap.of(
+                                "result", match,
+                                "matchPair", matchPair,
+                                "failureReasons", failures))
                         .type(MediaType.APPLICATION_JSON)
                         .build();
             }

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -326,6 +326,13 @@ definitions:
       matchPair:
         $ref: '#/definitions/DataUseMatchPair'
         description: The provided purpose and consent
+      failureReasons:
+        type: array
+        items:
+          type: string
+        description: |
+          Optional list of reasons why a match result may have failed. Only supported in
+          in versions 2 and higher
 
   Version:
     type: object

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
@@ -76,6 +77,7 @@ public class DataUseMatcherTest {
 
         when(autocompleteService.lookupById(intestinalCancerNode)).thenReturn(termResources);
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -104,6 +106,7 @@ public class DataUseMatcherTest {
 
         when(autocompleteService.lookupById(cancerNode)).thenReturn(termResources);
         assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -120,6 +123,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setHmbResearch(true).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -127,6 +131,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setHmbResearch(true).build();
         DataUse purpose = new DataUseBuilder().setGeneralUse(true).build();
         assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -134,6 +139,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setMethodsResearch(true).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -143,6 +149,7 @@ public class DataUseMatcherTest {
                 .setDiseaseRestrictions(Collections.singletonList(cancerNode))
                 .setMethodsResearch(true).build();
         assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     // TODO: This is confusing. In the context of a consented dataset, this means no aggregate research
@@ -152,6 +159,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).setAggregateResearch("No").build();
         DataUse purpose = new DataUseBuilder().setAggregateResearch("Yes").build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -159,6 +167,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setAggregateResearch("No").build(); // Not GRU or HMB
         DataUse purpose = new DataUseBuilder().setAggregateResearch("Yes").build();
         assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -166,6 +175,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setPopulationOriginsAncestry(true).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -173,6 +183,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setHmbResearch(true).build();
         DataUse purpose = new DataUseBuilder().setPopulationOriginsAncestry(true).build();
         assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -180,6 +191,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setCommercialUse(true).build();
         DataUse purpose = new DataUseBuilder().setCommercialUse(true).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -187,20 +199,15 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setCommercialUse(true).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
-    public void testCommercial_negative_1() {
+    public void testCommercial_negative() {
         DataUse dataset = new DataUseBuilder().setCommercialUse(false).build();
         DataUse purpose = new DataUseBuilder().setCommercialUse(true).build();
         assertFalse(matchPurposeAndDataset(purpose, dataset));
-    }
-
-    @Test
-    public void testCommercial_negative_2() {
-        DataUse dataset = new DataUseBuilder().setCommercialUse(true).build();
-        DataUse purpose = new DataUseBuilder().setCommercialUse(false).build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -208,6 +215,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setPediatric(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(true).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -215,6 +223,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(true).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -222,6 +231,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(false).build();
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -229,6 +239,7 @@ public class DataUseMatcherTest {
         DataUse dataset = new DataUseBuilder().setPediatric(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(false).build();
         assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -239,6 +250,7 @@ public class DataUseMatcherTest {
 
         purpose.setGender("Female");
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -249,6 +261,7 @@ public class DataUseMatcherTest {
 
         purpose.setGender("Female");
         assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     @Test
@@ -260,6 +273,7 @@ public class DataUseMatcherTest {
         dataset.setGender("Male");
         purpose.setGender("Female");
         assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
     }
 
     private boolean matchPurposeAndDataset(DataUse purpose, DataUse dataset) {
@@ -267,6 +281,16 @@ public class DataUseMatcherTest {
         matcher.setAutocompleteService(autocompleteService);
         try {
             return matcher.matchPurposeAndDatasetV2(purpose, dataset).getLeft();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<String> getMatchFailures(DataUse purpose, DataUse dataset) {
+        DataUseMatcher matcher = new DataUseMatcher();
+        matcher.setAutocompleteService(autocompleteService);
+        try {
+            return matcher.matchPurposeAndDatasetV2(purpose, dataset).getRight();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.consent.ontology.datause;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.broadinstitute.dsde.consent.ontology.resources.model.DataUse;
 import org.broadinstitute.dsde.consent.ontology.resources.model.DataUseBuilder;
 import org.broadinstitute.dsde.consent.ontology.resources.model.TermParent;
@@ -16,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
@@ -76,8 +76,7 @@ public class DataUseMatcherTest {
         termResources.add(resource);
 
         when(autocompleteService.lookupById(intestinalCancerNode)).thenReturn(termResources);
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
@@ -105,8 +104,7 @@ public class DataUseMatcherTest {
         termResources.add(resource);
 
         when(autocompleteService.lookupById(cancerNode)).thenReturn(termResources);
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
     @Test
@@ -115,31 +113,28 @@ public class DataUseMatcherTest {
                 .setDiseaseRestrictions(Collections.singletonList(cancerNode))
                 .build();
         DataUse purpose = new DataUseBuilder().build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertNegative(purpose, dataset);
     }
 
     @Test
     public void testHMB_positive() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setHmbResearch(true).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testHMB_negative() {
         DataUse dataset = new DataUseBuilder().setHmbResearch(true).build();
         DataUse purpose = new DataUseBuilder().setGeneralUse(true).build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
     @Test
     public void testNMDS_positive_case_1() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setMethodsResearch(true).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
@@ -148,8 +143,7 @@ public class DataUseMatcherTest {
         DataUse purpose = new DataUseBuilder()
                 .setDiseaseRestrictions(Collections.singletonList(cancerNode))
                 .setMethodsResearch(true).build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
     // TODO: This is confusing. In the context of a consented dataset, this means no aggregate research
@@ -158,139 +152,127 @@ public class DataUseMatcherTest {
     public void testNAGR_positive() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).setAggregateResearch("No").build();
         DataUse purpose = new DataUseBuilder().setAggregateResearch("Yes").build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testNAGR_negative() {
         DataUse dataset = new DataUseBuilder().setAggregateResearch("No").build(); // Not GRU or HMB
         DataUse purpose = new DataUseBuilder().setAggregateResearch("Yes").build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
     @Test
     public void testPOA_positive() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setPopulationOriginsAncestry(true).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testPOA_negative() {
         DataUse dataset = new DataUseBuilder().setHmbResearch(true).build();
         DataUse purpose = new DataUseBuilder().setPopulationOriginsAncestry(true).build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
     @Test
     public void testCommercial_positive_1() {
         DataUse dataset = new DataUseBuilder().setCommercialUse(true).build();
         DataUse purpose = new DataUseBuilder().setCommercialUse(true).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testCommercial_positive_2() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setCommercialUse(true).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testCommercial_negative() {
         DataUse dataset = new DataUseBuilder().setCommercialUse(false).build();
         DataUse purpose = new DataUseBuilder().setCommercialUse(true).build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
     @Test
     public void testPediatric_positive_1() {
         DataUse dataset = new DataUseBuilder().setPediatric(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(true).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testPediatric_positive_2() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(true).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testPediatric_positive_3() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(false).build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testPediatric_negative_1() {
         DataUse dataset = new DataUseBuilder().setPediatric(true).build();
         DataUse purpose = new DataUseBuilder().setPediatric(false).build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
     @Test
     public void testGenderMatch_positive_1() {
         DataUse dataset = new DataUseBuilder().setGeneralUse(true).build();
         DataUse purpose = new DataUseBuilder().setGender("Male").build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertPositive(purpose, dataset);
 
         purpose.setGender("Female");
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testGenderMatch_positive_2() {
         DataUse dataset = new DataUseBuilder().setGender("N/A").build();
         DataUse purpose = new DataUseBuilder().setGender("Male").build();
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
+        assertPositive(purpose, dataset);
 
         purpose.setGender("Female");
-        assertTrue(matchPurposeAndDataset(purpose, dataset));
-        assertTrue(getMatchFailures(purpose, dataset).isEmpty());
+        assertPositive(purpose, dataset);
     }
 
     @Test
     public void testGenderMatch_negative_1() {
         DataUse dataset = new DataUseBuilder().setGender("Female").build();
         DataUse purpose = new DataUseBuilder().setGender("Male").build();
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
+        assertNegative(purpose, dataset);
 
         dataset.setGender("Male");
         purpose.setGender("Female");
-        assertFalse(matchPurposeAndDataset(purpose, dataset));
-        assertFalse(getMatchFailures(purpose, dataset).isEmpty());
+        assertNegative(purpose, dataset);
     }
 
-    private boolean matchPurposeAndDataset(DataUse purpose, DataUse dataset) {
+    private void assertPositive(DataUse purpose, DataUse dataset) {
+        ImmutablePair<Boolean, List<String>> match = matchPurposeAndDataset(purpose, dataset);
+        assertTrue(match.getLeft());
+        assertTrue(match.getRight().isEmpty());
+    }
+
+    private void assertNegative(DataUse purpose, DataUse dataset) {
+        ImmutablePair<Boolean, List<String>> match = matchPurposeAndDataset(purpose, dataset);
+        assertFalse(match.getLeft());
+        assertFalse(match.getRight().isEmpty());
+    }
+
+    private ImmutablePair<Boolean, List<String>> matchPurposeAndDataset(DataUse purpose, DataUse dataset) {
         DataUseMatcher matcher = new DataUseMatcher();
         matcher.setAutocompleteService(autocompleteService);
         try {
-            return matcher.matchPurposeAndDatasetV2(purpose, dataset).getLeft();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private List<String> getMatchFailures(DataUse purpose, DataUse dataset) {
-        DataUseMatcher matcher = new DataUseMatcher();
-        matcher.setAutocompleteService(autocompleteService);
-        try {
-            return matcher.matchPurposeAndDatasetV2(purpose, dataset).getRight();
+            return matcher.matchPurposeAndDatasetV2(purpose, dataset);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherTest.java
@@ -266,7 +266,7 @@ public class DataUseMatcherTest {
         DataUseMatcher matcher = new DataUseMatcher();
         matcher.setAutocompleteService(autocompleteService);
         try {
-            return matcher.matchPurposeAndDataset(purpose, dataset);
+            return matcher.matchPurposeAndDatasetV2(purpose, dataset).getLeft();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/match/MatchTestBase.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/match/MatchTestBase.java
@@ -50,7 +50,7 @@ abstract class MatchTestBase extends TruthTableTests {
     public void parameterizedTest() throws IOException {
         DataUseMatcher matcher = new DataUseMatcher();
         matcher.setAutocompleteService(autocompleteService);
-        boolean algorithmMatch = matcher.matchPurposeAndDataset(purpose, consent);
+        boolean algorithmMatch = matcher.matchPurposeAndDatasetV2(purpose, consent).getLeft();
         String testMessage = testName + "; expected result: " + expectedMatchResult;
         assertEquals(testMessage, expectedMatchResult, algorithmMatch);
     }


### PR DESCRIPTION
## Addresses
See https://broadinstitute.atlassian.net/browse/DUOS-331

## Changes
Mostly a refactor of the individual match cases so we can add in failure strings to give the recipient more information about why the algorithm failed a particular purpose <-> consent match. 

## TODO
* Still need to run language by PO
* Increase test cases to check for expected errors