### PR TITLE
[risk=no] Address jackson security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <dropwizard.version>1.3.7</dropwizard.version>
         <metrics.version>4.0.3</metrics.version>
         <akka.version>2.4.20</akka.version>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.9.9.1</jackson.version>
         <jersey.version>2.19</jersey.version>
         <swagger.ui.version>2.2.8</swagger.ui.version>
         <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>


### PR DESCRIPTION
## Addresses
```
CVE-2019-12814
More information
moderate severity
Vulnerable versions: >= 2.0.0, < 2.9.9.1
Patched version: 2.9.9.1

A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has JDOM 1.x or 2.x jar in the classpath, an attacker can send a specifically crafted JSON message that allows them to read arbitrary local files on the server.
```