### PR TITLE
[risk=no] Security patches for jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,9 @@
         <owl.version>5.0.5</owl.version>
         <jena.version>2.6.4</jena.version>
         <lucene.version>7.1.0</lucene.version>
-        <dropwizard.version>1.3.7</dropwizard.version>
+        <dropwizard.version>1.3.14</dropwizard.version>
         <metrics.version>4.0.3</metrics.version>
         <akka.version>2.4.20</akka.version>
-        <jackson.version>2.9.9.1</jackson.version>
         <jersey.version>2.19</jersey.version>
         <swagger.ui.version>2.2.8</swagger.ui.version>
         <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
@@ -281,14 +280,6 @@
 
     <dependencies>
 
-        <!-- pull in jackson-databind directly to get a recent version without security warnings;
-                this is normally a transitive dependency -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
@@ -471,10 +462,6 @@
             <version>${dropwizard.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-jackson</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
@@ -509,10 +496,6 @@
                 <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Addresses
Update to the latest [dropwizard](https://www.dropwizard.io/1.3.14/docs/about/release-notes.html#v1-3-14-aug-7-2019) version which addresses the latest jackson issue. 

Covers these SC issues:
* https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039260/18759594
* https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/7039260/18759595