### PR TITLE
[DUOS-473][risk=no] Address Security Vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,18 @@
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
             <version>1.5.1</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-beanutils</artifactId>
+                    <groupId>commons-beanutils</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.parboiled/parboiled-java -->

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseTest.java
@@ -63,22 +63,6 @@ public class DataUseTest {
     }
 
     /*
-     * General schema validation tests
-     */
-
-    @Test
-    public void validateDataUseJsonFile() throws ValidationException, IOException {
-        try (InputStream schemaStream = new URL("http://json-schema.org/draft-04/schema").openStream()) {
-            String schemaString = FileUtils.readAllText(schemaStream);
-            JSONObject rawSchema = new JSONObject(new JSONTokener(schemaString));
-            Schema schema = SchemaLoader.load(rawSchema);
-            schema.validate(new JSONObject(DU_CONTENT)); // throws a ValidationException if this object is invalid
-        }
-    }
-
-
-
-    /*
      *  Tests that look at individual fields in DataUse
      */
 


### PR DESCRIPTION
## Addresses

https://broadinstitute.atlassian.net/browse/DUOS-473

## Changes
Library update due to SC report:

https://www.sourceclear.com/vulnerability-database/vulnerabilities/760
> Arbitrary Code Execution Through The Class Parameter Passed To The GetClass
> 
> commons-beanutils is vulnerable to arbitrary remote code execution. Attackers are able to leverage the missing suppression of the class property to manipulate the ClassLoader and execute code.
> 
> Update
> This issue was fixed in version 1.9.4 of Apache Commons BeanUtils. That version is currently considered safe, we suggest that you upgrade to the fixed version.

Additionally, there was a failing test that was hitting a redirect error from json schema. Removed test as it really isn't necessary.
