### PR TITLE
[no-jra][risk=no] Query param fix

### DIFF
--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -74,7 +74,7 @@ paths:
         - text/plain
       parameters:
         - name: for
-          in: body
+          in: query
           description: dataset or purpose
           required: true
           schema:


### PR DESCRIPTION
Parameter was specified incorrectly in the doc so was not passed to the API and failed in the swagger page.