### PR TITLE
[DUOS-498][risk=no] Circleci configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   jdk:
     docker:
-      - image: openjdk:8-jdk
+      - image: openjdk:8-jdk-stretch
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+    coveralls: coveralls/coveralls@1.0.4
+
 executors:
   jdk:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,10 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-      - run: mvn clean compile
-      - run: mvn test
+      - run: mvn clean jacoco:prepare-agent test jacoco:report
       - run: mvn dependency-check:check
       - store_artifacts:
-          path: target/dependency-check-report.html
-          destination: dependency-check-report.html
+          path: target
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,9 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-      - run: mvn clean verify
+      - run: mvn clean compile
+      - run: mvn test
+      - run: mvn dependency-check:check
       - run: mvn cobertura:cobertura coveralls:report
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-    coveralls: coveralls/coveralls@1.0.4
-
 executors:
   jdk:
     docker:
@@ -23,7 +20,7 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-      - run: mvn clean jacoco:prepare-agent test jacoco:report
+      - run: mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN}
       - run: mvn dependency-check:check
       - store_artifacts:
           path: target

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,16 @@ jobs:
     executor: jdk
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - run: mvn dependency:go-offline
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
       - run: mvn clean verify
       - run: mvn cobertura:cobertura coveralls:report
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   jdk:
     docker:
-      - image: openjdk:8-jdk-stretch
+      - image: openjdk:8-jdk
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,18 @@ jobs:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "pom.xml" }}
-      - run: mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN}
-      - run: mvn dependency-check:check
+      - run:
+          name: Clean & Test
+          command: mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN}
+      - run:
+          name: OWASP Dependency Checks
+          command: mvn dependency-check:check
       - store_artifacts:
-          path: target
+          path: target/dependency-check-report.html
+      - store_test_results:
+          path: target/surefire-reports
+      - store_test_results:
+          path: target/site/jacoco
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,4 @@ workflows:
   version: 2
   test:
     jobs:
-      - test:
-          filters:
-            branches:
-              only: circleci
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,9 @@ jobs:
       - run: mvn clean compile
       - run: mvn test
       - run: mvn dependency-check:check
-      - run: mvn cobertura:cobertura coveralls:report
+      - store_artifacts:
+          path: target/dependency-check-report.html
+          destination: dependency-check-report.html
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   jdk:
     docker:
-      - image: openjdk:8-jdk-stretch
+      - image: circleci/openjdk:8-jdk-stretch
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2.1
+
+executors:
+  jdk:
+    docker:
+      - image: openjdk:8-jdk-stretch
+
+jobs:
+  test:
+    executor: jdk
+    steps:
+      - checkout
+      - run: mvn clean verify
+      - run: mvn cobertura:cobertura coveralls:report
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test:
+          filters:
+            branches:
+              only: circleci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: java
-jdk:
-  - openjdk8
-script:
-  - mvn clean verify
-after_success:
-  - mvn cobertura:cobertura coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
-                    <argLine>-Xmx1024m</argLine>
+                    <argLine>@{argLine} -Xmx1024m</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
                     </systemPropertyVariables>
@@ -174,22 +174,23 @@
             </plugin>
 
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <format>xml</format>
-                    <maxmem>256m</maxmem>
-                    <!-- aggregated reports for multi-module projects -->
-                    <aggregate>true</aggregate>
-                    <check/>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
+                    <!-- @{argLine} is necessary here so that that the jacoco:prepare-agent output is included for tests -->
                     <argLine>@{argLine} -Xmx1024m</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-498

## Changes
* Use circle instead of travis.
* Cobertura was complaining about parsing `<` in the test result files. Looks like the plugin hasn't been updated in quite some time. Ditch that for jacoco which seems a little more forgiving. 