### PR TITLE
[DUOS-377][risk=no] Upgrade to DW 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,10 +278,9 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>1.3.9-2</version>
+            <version>2.0.0-4</version>
         </dependency>
 
-        <!-- https://github.com/everit-org/json-schema -->
         <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
@@ -300,7 +299,6 @@
             <version>1.9.4</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.parboiled/parboiled-java -->
         <dependency>
             <groupId>org.parboiled</groupId>
             <artifactId>parboiled-java</artifactId>
@@ -329,12 +327,6 @@
         </dependency>
 
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>28.2-jre</version>
@@ -357,10 +349,12 @@
             <artifactId>google-api-client</artifactId>
             <version>1.30.8</version>
             <exclusions>
+                <!-- SourceClear fix https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391949/3285366 -->
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient-osgi</artifactId>
                 </exclusion>
+                <!-- SourceClear fix https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391949/3285366 -->
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
@@ -447,7 +441,21 @@
 
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-dependencies</artifactId>
+            <version>${dropwizard.version}</version>
+            <type>pom</type>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-auth</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
 
@@ -455,30 +463,23 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <version>${dropwizard.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-                    <artifactId>jersey-test-framework-provider-inmemory</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-servlets</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-jackson</artifactId>
+            <artifactId>dropwizard-http2</artifactId>
             <version>${dropwizard.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <version>${dropwizard.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -487,13 +488,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
+            <version>2.10.2</version>
         </dependency>
 
         <dependency>
@@ -686,19 +681,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-testing</artifactId>
-            <version>${dropwizard.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
@@ -719,48 +701,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
-            <version>${jersey.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
-            <version>2.30</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>4.2.2</version>
@@ -771,5 +711,7 @@
             <artifactId>swagger-ui</artifactId>
             <version>${swagger.ui.version}</version>
         </dependency>
+
     </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,20 +3,19 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.broadinstitute</groupId>
     <artifactId>consent-ontology</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
     <name>Consent Management: Ontology Services</name>
 
     <properties>
-        <java.version>1.8</java.version>
-        <pellet.version>2.3.6-ansell</pellet.version>
-        <owl.version>5.1.13</owl.version>
-        <jena.version>2.6.4</jena.version>
-        <lucene.version>8.4.1</lucene.version>
-        <dropwizard.version>1.3.18</dropwizard.version>
-        <metrics.version>4.1.2</metrics.version>
         <akka.version>2.5.29</akka.version>
+        <dropwizard.version>2.0.1</dropwizard.version>
+        <java.version>1.8</java.version>
+        <jena.version>2.6.4</jena.version>
         <jersey.version>2.19</jersey.version>
+        <lucene.version>8.4.1</lucene.version>
+        <owl.version>5.1.13</owl.version>
+        <pellet.version>2.3.6-ansell</pellet.version>
         <rdf4j-rio.version>3.1.0</rdf4j-rio.version>
         <swagger.ui.version>2.2.8</swagger.ui.version>
         <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
@@ -279,10 +278,9 @@
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
-            <version>1.3.9-2</version>
+            <version>2.0.0-4</version>
         </dependency>
 
-        <!-- https://github.com/everit-org/json-schema -->
         <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
@@ -301,7 +299,6 @@
             <version>1.9.4</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.parboiled/parboiled-java -->
         <dependency>
             <groupId>org.parboiled</groupId>
             <artifactId>parboiled-java</artifactId>
@@ -329,11 +326,11 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>ch.qos.logback</groupId>-->
+<!--            <artifactId>logback-classic</artifactId>-->
+<!--            <version>1.2.3</version>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -358,28 +355,23 @@
             <artifactId>google-api-client</artifactId>
             <version>1.30.8</version>
             <exclusions>
+                <!-- SourceClear fix https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391949/3285366 -->
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient-osgi</artifactId>
                 </exclusion>
+                <!-- SourceClear fix https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391949/3285366 -->
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
                 </exclusion>
             </exclusions>
-
         </dependency>
 
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-storage</artifactId>
             <version>v1-rev20191011-1.30.3</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>com.google.api-client</artifactId>
-                    <groupId>google-api-client</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- SourceClear fix https://broadinstitute-dsp.sourceclear.io/teams/jppForw/issues/vulnerabilities/5391949/3285366 -->
@@ -455,7 +447,21 @@
 
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-dependencies</artifactId>
+            <version>${dropwizard.version}</version>
+            <type>pom</type>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-auth</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
 
@@ -463,30 +469,23 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <version>${dropwizard.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-                    <artifactId>jersey-test-framework-provider-inmemory</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-servlets</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-jackson</artifactId>
+            <artifactId>dropwizard-http2</artifactId>
             <version>${dropwizard.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <version>${dropwizard.version}</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -495,13 +494,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>${metrics.version}</version>
+            <version>2.10.2</version>
         </dependency>
 
         <dependency>
@@ -694,19 +687,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-testing</artifactId>
-            <version>${dropwizard.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
@@ -727,48 +707,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
-            <version>${jersey.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
-            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
-            <version>2.30</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>4.2.2</version>
@@ -779,5 +717,7 @@
             <artifactId>swagger-ui</artifactId>
             <version>${swagger.ui.version}</version>
         </dependency>
+
     </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.broadinstitute</groupId>
     <artifactId>consent-ontology</artifactId>
-    <version>2.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
     <name>Consent Management: Ontology Services</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -326,12 +326,6 @@
             <scope>test</scope>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>ch.qos.logback</groupId>-->
-<!--            <artifactId>logback-classic</artifactId>-->
-<!--            <version>1.2.3</version>-->
-<!--        </dependency>-->
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -38,9 +38,7 @@ public class OntologyApp extends Application<OntologyConfiguration> {
     public static void main(String[] args) throws Exception {
         String dsn = System.getProperties().getProperty("sentry.dsn");
         if (StringUtils.isNotBlank(dsn)) {
-            SentryBootstrap.Builder.
-                    withDsn(dsn).
-                    bootstrap();
+            SentryBootstrap.Builder.withDsn(dsn).bootstrap();
             Thread.currentThread().setUncaughtExceptionHandler(UncaughtExceptionHandlers.systemExit());
         }
         new OntologyApp().run(args);

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -6,6 +6,7 @@ import io.dropwizard.Application;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
 import org.broadinstitute.dsde.consent.ontology.resources.AutocompleteResource;
 import org.broadinstitute.dsde.consent.ontology.resources.DataUseResource;
@@ -36,8 +37,10 @@ public class OntologyApp extends Application<OntologyConfiguration> {
 
     public static void main(String[] args) throws Exception {
         String dsn = System.getProperties().getProperty("sentry.dsn");
-        if (null != dsn && !dsn.isEmpty()) {
-            SentryBootstrap.bootstrap(dsn);
+        if (StringUtils.isNotBlank(dsn)) {
+            SentryBootstrap.Builder.
+                    withDsn(dsn).
+                    bootstrap();
             Thread.currentThread().setUncaughtExceptionHandler(UncaughtExceptionHandlers.systemExit());
         }
         new OntologyApp().run(args);

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -30,8 +30,7 @@ import java.util.EnumSet;
  * Top-level entry point to the entire application.
  *
  * See the Dropwizard docs here:
- * https://dropwizard.github.io/dropwizard/manual/core.html
- *
+ * https://www.dropwizard.io/
  */
 public class OntologyApp extends Application<OntologyConfiguration> {
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcher.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcher.java
@@ -1,20 +1,20 @@
 package org.broadinstitute.dsde.consent.ontology.datause;
 
 import com.google.inject.Inject;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.log4j.Logger;
-import org.broadinstitute.dsde.consent.ontology.Utils;
 import org.broadinstitute.dsde.consent.ontology.resources.model.DataUse;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCases.matchCommercial;
 import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCases.matchControlSet;
@@ -28,11 +28,10 @@ import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCases
 
 public class DataUseMatcher {
 
-    private final Logger log = Utils.getLogger(this.getClass());
-
     private AutocompleteService autocompleteService;
 
-    public DataUseMatcher() { }
+    public DataUseMatcher() {
+    }
 
     @Inject
     public void setAutocompleteService(AutocompleteService autocompleteService) {
@@ -42,51 +41,26 @@ public class DataUseMatcher {
     // Matching Algorithm
     public ImmutablePair<Boolean, List<String>> matchPurposeAndDatasetV2(DataUse purpose, DataUse dataset) throws IOException {
         Map<String, List<String>> purposeDiseaseIdMap = purposeDiseaseIdMap(purpose.getDiseaseRestrictions());
-
         ImmutablePair<Boolean, List<String>> diseaseMatch = matchDiseases(purpose, dataset, purposeDiseaseIdMap);
-        ImmutablePair<Boolean, List<String>> hmbMatch = matchHMB(purpose, dataset, diseaseMatch.getLeft());
-        ImmutablePair<Boolean, List<String>> nmdsMatch = matchNMDS(purpose, dataset, diseaseMatch.getLeft());
-        ImmutablePair<Boolean, List<String>> controlMatch = matchControlSet(purpose, dataset, diseaseMatch.getLeft());
-        ImmutablePair<Boolean, List<String>> nagrMatch = matchNAGR(purpose, dataset);
-        ImmutablePair<Boolean, List<String>> poaMatch = matchPOA(purpose, dataset);
-        ImmutablePair<Boolean, List<String>> commercialMatch = matchCommercial(purpose, dataset);
-        ImmutablePair<Boolean, List<String>> pediatricMatch = matchRSPD(purpose, dataset);
-        ImmutablePair<Boolean, List<String>> genderMatch = matchRSG(purpose, dataset);
 
-        log.debug("hmbMatch: " + hmbMatch.getLeft());
-        log.debug("diseaseMatch: " + diseaseMatch.getLeft());
-        log.debug("nmdsMatch: " + nmdsMatch.getLeft());
-        log.debug("controlMatch: " + controlMatch.getLeft());
-        log.debug("nagrMatch: " + nagrMatch.getLeft());
-        log.debug("poaMatch: " + poaMatch.getLeft());
-        log.debug("commercialMatch: " + commercialMatch.getLeft());
-        log.debug("pediatricMatch: " + pediatricMatch.getLeft());
-        log.debug("genderMatch: " + genderMatch.getLeft());
-
-        Boolean match = hmbMatch.getLeft() &&
-                diseaseMatch.getLeft() &&
-                nmdsMatch.getLeft() &&
-                controlMatch.getLeft() &&
-                nagrMatch.getLeft() &&
-                poaMatch.getLeft() &&
-                commercialMatch.getLeft() &&
-                pediatricMatch.getLeft() &&
-                genderMatch.getLeft();
-
-        List<String> reasons = Stream.of(
-                hmbMatch.getRight(),
-                diseaseMatch.getRight(),
-                nmdsMatch.getRight(),
-                controlMatch.getRight(),
-                nagrMatch.getRight(),
-                poaMatch.getRight(),
-                commercialMatch.getRight(),
-                pediatricMatch.getRight(),
-                genderMatch.getRight())
-                .flatMap(Collection::stream)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-
+        final List<ImmutablePair<Boolean, List<String>>> matchReasons = new ArrayList<>();
+        matchReasons.add(matchDiseases(purpose, dataset, purposeDiseaseIdMap));
+        matchReasons.add(matchHMB(purpose, dataset, diseaseMatch.getLeft()));
+        matchReasons.add(matchNMDS(purpose, dataset, diseaseMatch.getLeft()));
+        matchReasons.add(matchControlSet(purpose, dataset, diseaseMatch.getLeft()));
+        matchReasons.add(matchNAGR(purpose, dataset));
+        matchReasons.add(matchPOA(purpose, dataset));
+        matchReasons.add(matchCommercial(purpose, dataset));
+        matchReasons.add(matchRSPD(purpose, dataset));
+        matchReasons.add(matchRSG(purpose, dataset));
+        final Boolean match = matchReasons.stream().
+                map(ImmutablePair::getLeft).
+                allMatch(BooleanUtils::isTrue);
+        final List<String> reasons = matchReasons.stream().
+                map(ImmutablePair::getRight).
+                flatMap(Collection::stream).
+                filter(StringUtils::isNotBlank).
+                collect(Collectors.toList());
         return ImmutablePair.of(match, reasons);
     }
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcher.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcher.java
@@ -1,20 +1,20 @@
 package org.broadinstitute.dsde.consent.ontology.datause;
 
 import com.google.inject.Inject;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.log4j.Logger;
+import org.broadinstitute.dsde.consent.ontology.Utils;
 import org.broadinstitute.dsde.consent.ontology.resources.model.DataUse;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCases.matchCommercial;
 import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCases.matchControlSet;
@@ -28,10 +28,11 @@ import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCases
 
 public class DataUseMatcher {
 
+    private final Logger log = Utils.getLogger(this.getClass());
+
     private AutocompleteService autocompleteService;
 
-    public DataUseMatcher() {
-    }
+    public DataUseMatcher() { }
 
     @Inject
     public void setAutocompleteService(AutocompleteService autocompleteService) {
@@ -41,26 +42,51 @@ public class DataUseMatcher {
     // Matching Algorithm
     public ImmutablePair<Boolean, List<String>> matchPurposeAndDatasetV2(DataUse purpose, DataUse dataset) throws IOException {
         Map<String, List<String>> purposeDiseaseIdMap = purposeDiseaseIdMap(purpose.getDiseaseRestrictions());
-        ImmutablePair<Boolean, List<String>> diseaseMatch = matchDiseases(purpose, dataset, purposeDiseaseIdMap);
 
-        final List<ImmutablePair<Boolean, List<String>>> matchReasons = new ArrayList<>();
-        matchReasons.add(matchDiseases(purpose, dataset, purposeDiseaseIdMap));
-        matchReasons.add(matchHMB(purpose, dataset, diseaseMatch.getLeft()));
-        matchReasons.add(matchNMDS(purpose, dataset, diseaseMatch.getLeft()));
-        matchReasons.add(matchControlSet(purpose, dataset, diseaseMatch.getLeft()));
-        matchReasons.add(matchNAGR(purpose, dataset));
-        matchReasons.add(matchPOA(purpose, dataset));
-        matchReasons.add(matchCommercial(purpose, dataset));
-        matchReasons.add(matchRSPD(purpose, dataset));
-        matchReasons.add(matchRSG(purpose, dataset));
-        final Boolean match = matchReasons.stream().
-                map(ImmutablePair::getLeft).
-                allMatch(BooleanUtils::isTrue);
-        final List<String> reasons = matchReasons.stream().
-                map(ImmutablePair::getRight).
-                flatMap(Collection::stream).
-                filter(StringUtils::isNotBlank).
-                collect(Collectors.toList());
+        ImmutablePair<Boolean, List<String>> diseaseMatch = matchDiseases(purpose, dataset, purposeDiseaseIdMap);
+        ImmutablePair<Boolean, List<String>> hmbMatch = matchHMB(purpose, dataset, diseaseMatch.getLeft());
+        ImmutablePair<Boolean, List<String>> nmdsMatch = matchNMDS(purpose, dataset, diseaseMatch.getLeft());
+        ImmutablePair<Boolean, List<String>> controlMatch = matchControlSet(purpose, dataset, diseaseMatch.getLeft());
+        ImmutablePair<Boolean, List<String>> nagrMatch = matchNAGR(purpose, dataset);
+        ImmutablePair<Boolean, List<String>> poaMatch = matchPOA(purpose, dataset);
+        ImmutablePair<Boolean, List<String>> commercialMatch = matchCommercial(purpose, dataset);
+        ImmutablePair<Boolean, List<String>> pediatricMatch = matchRSPD(purpose, dataset);
+        ImmutablePair<Boolean, List<String>> genderMatch = matchRSG(purpose, dataset);
+
+        log.debug("hmbMatch: " + hmbMatch.getLeft());
+        log.debug("diseaseMatch: " + diseaseMatch.getLeft());
+        log.debug("nmdsMatch: " + nmdsMatch.getLeft());
+        log.debug("controlMatch: " + controlMatch.getLeft());
+        log.debug("nagrMatch: " + nagrMatch.getLeft());
+        log.debug("poaMatch: " + poaMatch.getLeft());
+        log.debug("commercialMatch: " + commercialMatch.getLeft());
+        log.debug("pediatricMatch: " + pediatricMatch.getLeft());
+        log.debug("genderMatch: " + genderMatch.getLeft());
+
+        Boolean match = hmbMatch.getLeft() &&
+                diseaseMatch.getLeft() &&
+                nmdsMatch.getLeft() &&
+                controlMatch.getLeft() &&
+                nagrMatch.getLeft() &&
+                poaMatch.getLeft() &&
+                commercialMatch.getLeft() &&
+                pediatricMatch.getLeft() &&
+                genderMatch.getLeft();
+
+        List<String> reasons = Stream.of(
+                hmbMatch.getRight(),
+                diseaseMatch.getRight(),
+                nmdsMatch.getRight(),
+                controlMatch.getRight(),
+                nagrMatch.getRight(),
+                poaMatch.getRight(),
+                commercialMatch.getRight(),
+                pediatricMatch.getRight(),
+                genderMatch.getRight())
+                .flatMap(Collection::stream)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
         return ImmutablePair.of(match, reasons);
     }
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/models/UseRestriction.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/models/UseRestriction.java
@@ -3,12 +3,12 @@ package org.broadinstitute.dsde.consent.ontology.datause.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.gson.Gson;
 import com.hp.hpl.jena.ontology.OntClass;
 import com.hp.hpl.jena.ontology.OntModel;
-import io.dropwizard.jackson.Jackson;
 import org.broadinstitute.dsde.consent.ontology.datause.models.visitor.UseRestrictionVisitor;
 
 import java.io.IOException;
@@ -29,7 +29,8 @@ import java.io.IOException;
 })
 public abstract class UseRestriction {
 
-    private static ObjectMapper mapper = Jackson.newObjectMapper();
+    private static ObjectMapper mapper = new ObjectMapper().
+            configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
     public abstract OntClass createOntologicalRestriction(OntModel model);
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-377
Have manually tested all endpoints.
Helpful resources:
* https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-1.3.x-to-2.0.x
* https://github.com/dhatim/dropwizard-sentry


## Changes
* Dropwizard libraries
* Dhatim Sentry library
* Jackson library
  * ObjectMapper changed behavior slightly. It now doesn't auto-fail on unknown properties, whereas the older version did.

**OWASP** reports:
```
logback-throttling-appender-1.1.0.jar (pkg:maven/io.dropwizard.logback/logback-throttling-appender@1.1.0, cpe:2.3:a:logback:logback:1.1.0:*:*:*:*:*:*:*) : CVE-2017-5929
handlebars-4.0.5.js (pkg:javascript/handlebars.js@4.0.5) : A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template, Disallow calling helperMissing and blockHelperMissing directly, Prototype pollution
jquery-1.8.0.min.js (pkg:javascript/jquery@1.8.0.min) : CVE-2012-6708, CVE-2015-9251, CVE-2019-11358
```
The only thing new is `logback-throttling-appender-1.1.0.jar` which is the latest version and doesn't look like there is a mitigation strategy for.  `handlebars-4.0.5.js` and `jquery-1.8.0.min.js` will be addressed in https://github.com/DataBiosphere/consent-ontology/pull/208