### PR TITLE
[no jira][risk=no] Data Use Summary Translation

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationService.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationService.java
@@ -1,10 +1,14 @@
 package org.broadinstitute.dsde.consent.ontology.datause.services;
 
+import org.broadinstitute.dsde.consent.ontology.resources.model.DataUseSummary;
+
 import java.io.IOException;
 
 public interface TextTranslationService {
 
     enum TranslateFor { DATASET, PURPOSE }
+
+    DataUseSummary translateDataUseSummary(String dataUseString);
 
     String translateDataset(String dataUse) throws IOException;
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java
@@ -138,7 +138,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
             }
         }
         if (BooleanUtils.isTrue(dataUse.getPopulationOriginsAncestry())) {
-            primary.add(new DataUseElement("POA", POA_POS));
+            primary.add(new DataUseElement("NPOA", POA_POS));
         }
 
         if (BooleanUtils.isTrue(dataUse.getCommercialUse())) {
@@ -171,10 +171,10 @@ public class TextTranslationServiceImpl implements TextTranslationService {
         }
 
         if (Optional.ofNullable(dataUse.getGender()).orElse("na").equalsIgnoreCase(MALE)) {
-            secondary.add(new DataUseElement("RS-M", RS_M_POS));
+            secondary.add(new DataUseElement("POP-M", RS_M_POS));
         }
         if (Optional.ofNullable(dataUse.getGender()).orElse("na").equalsIgnoreCase(FEMALE)) {
-            secondary.add(new DataUseElement("RS-F", RS_FM_POS));
+            secondary.add(new DataUseElement("POP-F", RS_FM_POS));
         }
 
         // TODO: In ORSP, we query DatabioOntology services, not consent.
@@ -183,10 +183,10 @@ public class TextTranslationServiceImpl implements TextTranslationService {
                     .stream()
                     .filter(StringUtils::isNotBlank)
                     .collect(Collectors.joining(", "));
-            secondary.add(new DataUseElement("RS-POP", String.format(RS_POS, popRestrictions)));
+            secondary.add(new DataUseElement("POP", String.format(RS_POS, popRestrictions)));
         }
         if (BooleanUtils.isTrue(dataUse.getPediatric())) {
-            secondary.add(new DataUseElement("RS-PD", RS_PD_POS));
+            secondary.add(new DataUseElement("POP-PD", RS_PD_POS));
         }
         if (StringUtils.isNotBlank(dataUse.getDateRestriction())) {
             try {
@@ -197,7 +197,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
             }
         }
         if (Optional.ofNullable(dataUse.getAggregateResearch()).orElse("na").equalsIgnoreCase(YES)) {
-            secondary.add(new DataUseElement("OTHER", AGGREGATE_POS));
+            secondary.add(new DataUseElement("NAGG", AGGREGATE_POS));
         }
         if (dataUse.getRecontactMay() != null) {
             secondary.add(new DataUseElement("OTHER", String.format(RECONTACT_MAY, dataUse.getRecontactMay())));

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java
@@ -57,14 +57,13 @@ public class TextTranslationServiceImpl implements TextTranslationService {
     private static final String GENETIC_STUDIES_ONLY = "Future use is limited to genetic studies only [GSO]";
     private static final String PUBLICATION_REQUIRED = "Publishing results of studies using the data available to the larger scientific community is required";
     private static final String GENOMIC_RESULTS = "Genomic summary results from this study are available only through controlled-access";
-    private static final String COLLABORATION_INVESTIGATOR = "Collaboration with the primary study investigators required";
+    private static final String COLLABORATION_REQUIRED = "Collaboration with the primary study investigators required.";
 
     // Terms of use/notes
     private static final String RECONTACT_MAY = "Subject re-contact may occur in certain circumstances, as specified: %s";
     private static final String RECONTACT_MUST = "Subject re-contact must occur in certain circumstances, as specified: %s";
     private static final String CLOUD_PROHIBITED = "Data storage on the cloud is prohibited.";
     private static final String ETHICS_APPROVAL = "Local ethics committee approval is required.";
-    private static final String COLLABORATOR_REQUIRED = "Collaborator approval is required.";
     private static final String GEO_RESTRICTION = "Geographical restrictions: %s.";
     private static final String OTHER_POS = "Other restrictions: %s.";
 
@@ -218,7 +217,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
             secondary.add(new DataUseElement("IRB", ETHICS_APPROVAL));
         }
         if (BooleanUtils.isTrue(dataUse.getCollaboratorRequired())) {
-            secondary.add(new DataUseElement("OTHER", COLLABORATOR_REQUIRED));
+            secondary.add(new DataUseElement("COL", COLLABORATION_REQUIRED));
         }
         if (BooleanUtils.isTrue(dataUse.getManualReview())) {
             secondary.add(new DataUseElement("OTHER", MANUAL_REVIEW));
@@ -236,7 +235,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
             secondary.add(new DataUseElement("OTHER", dataUse.getGenomicSummaryResults()));
         }
         if (BooleanUtils.isTrue(dataUse.getCollaborationInvestigators())) {
-            secondary.add(new DataUseElement("COL", COLLABORATION_INVESTIGATOR));
+            secondary.add(new DataUseElement("COL", COLLABORATION_REQUIRED));
         }
 
         summary.setPrimary(primary);
@@ -364,7 +363,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
             summary.add(ETHICS_APPROVAL);
         }
         if (BooleanUtils.isTrue(dataUse.getCollaboratorRequired())) {
-            summary.add(COLLABORATOR_REQUIRED);
+            summary.add(COLLABORATION_REQUIRED);
         }
         if (BooleanUtils.isTrue(dataUse.getManualReview())) {
             summary.add(MANUAL_REVIEW);
@@ -382,7 +381,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
             summary.add(dataUse.getGenomicSummaryResults());
         }
         if (BooleanUtils.isTrue(dataUse.getCollaborationInvestigators())) {
-            summary.add(COLLABORATION_INVESTIGATOR);
+            summary.add(COLLABORATION_REQUIRED);
         }
 
         return String.join("\n", summary);

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/TranslateResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/TranslateResource.java
@@ -25,6 +25,21 @@ public class TranslateResource {
     }
 
     @POST
+    @Path("summary")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response translateSummary(String restriction) {
+        try {
+            return Response.ok().entity(translationService.translateDataUseSummary(restriction)).build();
+        } catch (Exception e) {
+            log.error("Error while translating", e);
+            return Response.
+                    status(Response.Status.INTERNAL_SERVER_ERROR).
+                    entity("Error while translating: " + e.getMessage()).
+                    build();
+        }
+    }
+
+    @POST
     @Consumes(MediaType.APPLICATION_JSON)
     public Response translate(@QueryParam("for") String forParam, String restriction) {
         try {

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseElement.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseElement.java
@@ -1,0 +1,27 @@
+package org.broadinstitute.dsde.consent.ontology.resources.model;
+
+public class DataUseElement {
+    String code;
+    String description;
+
+    public DataUseElement(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseElement.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseElement.java
@@ -5,8 +5,8 @@ public class DataUseElement {
     String description;
 
     public DataUseElement(String code, String description) {
-        this.code = code;
-        this.description = description;
+        setCode(code);
+        setDescription(description);
     }
 
     public String getCode() {
@@ -22,6 +22,6 @@ public class DataUseElement {
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        this.description = description.replaceAll("\\[.+]", "").trim();
     }
 }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseSummary.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseSummary.java
@@ -1,0 +1,34 @@
+package org.broadinstitute.dsde.consent.ontology.resources.model;
+
+import java.util.List;
+
+public class DataUseSummary {
+
+    List<DataUseElement> primary;
+    List<DataUseElement> secondary;
+
+    public DataUseSummary() {
+    }
+
+    public DataUseSummary(List<DataUseElement> primary, List<DataUseElement> secondary) {
+        this.primary = primary;
+        this.secondary = secondary;
+    }
+
+    public List<DataUseElement> getPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(List<DataUseElement> primary) {
+        this.primary = primary;
+    }
+
+    public List<DataUseElement> getSecondary() {
+        return secondary;
+    }
+
+    public void setSecondary(List<DataUseElement> secondary) {
+        this.secondary = secondary;
+    }
+
+}

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -113,6 +113,8 @@ paths:
       responses:
         200:
           description: Successful translation.
+          schema:
+            $ref: '#/definitions/DataUseSummary'
         default:
           description: Unexpected error
 
@@ -322,6 +324,39 @@ definitions:
         type: boolean
       matchPair:
         $ref: '#/definitions/MatchPair'
+
+  DataUseElement:
+    type: object
+    description: Individual element of a DataUseSummary object
+    properties:
+      code:
+        type: string
+        description: Consent Code
+      description:
+        type: string
+        description: Consent Code Description
+    example:
+      { "code": "GRU", "description": "Data is available for general research use. [GRU]"}
+
+  DataUseSummary:
+    type: object
+    description: Structured summary of a DataUse object
+    properties:
+      primary:
+        description: List of primary consent codes
+        type: array
+        items:
+          $ref: '#/definitions/DataUseElement'
+      secondary:
+        type: array
+        description: List of secondary consent codes
+        items:
+          $ref: '#/definitions/DataUseElement'
+    example:
+      {
+        "primary": ["code": "GRU", "description": "Data is available for general research use. [GRU]"],
+        "secondary": ["code": "OTHER", "description": "Data storage on the cloud is prohibited."]
+      }
 
   DataUse:
     type: object

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -73,13 +73,11 @@ paths:
       produces:
         - text/plain
       parameters:
-        - name: for
-          in: query
-          description: dataset or purpose
+        - in: query
+          name: for
+          description: Either 'dataset' or 'purpose'
           required: true
-          schema:
-            type: string
-            enum: [dataset, purpose]
+          type: string
         - name: body
           in: body
           description: DataUse

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -9,7 +9,7 @@ info:
   termsOfService: 'https://github.com/DataBiosphere/consent-ontology'
 schemes:
   - https
-  
+
 paths:
 
   /schemas/data-use:
@@ -70,7 +70,7 @@ paths:
     post:
       summary: Translate Data Use JSON into plain English
       description: The Translate service will render an English-language version of a research purpose or dataset.
-      produces: 
+      produces:
         - text/plain
       parameters:
         - name: for
@@ -80,6 +80,27 @@ paths:
           schema:
             type: string
             enum: [dataset, purpose]
+        - name: body
+          in: body
+          description: DataUse
+          required: true
+          schema:
+            $ref: '#/definitions/DataUse'
+      tags:
+        - Data Use
+        - Translate
+      responses:
+        200:
+          description: Successful translation.
+        default:
+          description: Unexpected error
+  /translate/summary:
+    post:
+      summary: Translate Data Use JSON into Data Use Summary JSON
+      description: The Translate service will render an structured summary with consent codes
+      produces:
+        - application/json
+      parameters:
         - name: body
           in: body
           description: DataUse
@@ -115,7 +136,7 @@ paths:
             $ref: '#/definitions/MatchPairResult'
         500:
           description: Internal Server Error
-          
+
   /match/v1:
     post:
       summary: Match UseRestriction Consent and Research Purpose
@@ -275,7 +296,7 @@ definitions:
         type: object
         description: UseRestriction of the research purpose
         properties:
-          type: 
+          type:
             type: string
           operands:
             type: array
@@ -286,7 +307,7 @@ definitions:
         type: object
         description: UseRestriction of the consent
         properties:
-          type: 
+          type:
             type: string
           operands:
             type: array

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -78,6 +78,7 @@ paths:
           description: Either 'dataset' or 'purpose'
           required: true
           type: string
+          enum: [dataset, purpose]
         - name: body
           in: body
           description: DataUse

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImplTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImplTest.java
@@ -18,6 +18,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -59,6 +61,10 @@ public class TextTranslationServiceImplTest extends AbstractTest {
         DataUseSummary summary = service.translateDataUseSummary(dataUseString);
         assertFalse(summary.getPrimary().isEmpty());
         assertTrue(summary.getPrimary().get(0).getCode().equalsIgnoreCase("GRU"));
+        Stream.of(summary.getPrimary(), summary.getSecondary()).flatMap(List::stream).forEach(e -> {
+            assertFalse(e.getDescription().contains("["));
+            assertFalse(e.getDescription().contains("]"));
+        });
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImplTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImplTest.java
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.consent.ontology.AbstractTest;
 import org.broadinstitute.dsde.consent.ontology.Utils;
 import org.broadinstitute.dsde.consent.ontology.resources.model.DataUse;
 import org.broadinstitute.dsde.consent.ontology.resources.model.DataUseBuilder;
+import org.broadinstitute.dsde.consent.ontology.resources.model.DataUseSummary;
 import org.broadinstitute.dsde.consent.ontology.resources.model.TermResource;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 import org.junit.After;
@@ -48,6 +49,16 @@ public class TextTranslationServiceImplTest extends AbstractTest {
 
     @After
     public void tearDownClass() {
+    }
+
+    @Test
+    public void testTranslateSummary() {
+        Gson gson = new Gson();
+        DataUse dataUse = new DataUseBuilder().setGeneralUse(true).build();
+        String dataUseString = gson.toJson(dataUse);
+        DataUseSummary summary = service.translateDataUseSummary(dataUseString);
+        assertFalse(summary.getPrimary().isEmpty());
+        assertTrue(summary.getPrimary().get(0).getCode().equalsIgnoreCase("GRU"));
     }
 
     @Test

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/MockTranslationService.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/MockTranslationService.java
@@ -1,8 +1,14 @@
 package org.broadinstitute.dsde.consent.ontology.service;
 
 import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationService;
+import org.broadinstitute.dsde.consent.ontology.resources.model.DataUseSummary;
 
 public class MockTranslationService implements TextTranslationService {
+
+    @Override
+    public DataUseSummary translateDataUseSummary(String dataUseString) {
+        return new DataUseSummary();
+    }
 
     @Override
     public String translateDataset(String dataUse) {


### PR DESCRIPTION
## Addresses
Translates a DataUse schema object to a summary version with consent codes.

This:
```
{
  "generalUse": false,
  "hmbResearch": true,
  "diseaseRestrictions": [
    "http://purl.obolibrary.org/obo/DOID_602"
  ]
}
```
translates to this:
```
{
  "primary": [
    {
      "code": "HMB",
      "description": "Data is limited for health/medical/biomedical research. [HMB]"
    },
    {
      "code": "DS",
      "description": "Data use is limited for studying: cancerophobia [DS]"
    }
  ],
  "secondary": [
    {
      "code": "NCU",
      "description": "Commercial use is not prohibited."
    },
    {
      "code": "NMDS",
      "description": "Data use for methods development research irrespective of the specified data use limitations is not prohibited."
    },
    {
      "code": "NCTRL",
      "description": "Restrictions for use as a control set for diseases other than those defined were not specified."
    }
  ]
}
```