### PR TITLE
[DUOS-740][risk=no] Use alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
-FROM openjdk:8
-
-# Standard apt-get cleanup.
-RUN apt-get -yq autoremove && \
-    apt-get -yq clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/* && \
-    rm -rf /var/tmp/*
+FROM openjdk:8-alpine
 
 COPY target/consent-ontology.jar /opt/consent-ontology.jar


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-740

## Root Cause(s)
1. openJDK:8 has updated to [8u265](https://hub.docker.com/layers/openjdk/library/openjdk/8u265/images/sha256-34da86101369dd0a9cc74a696c3f0a38cb5eb0f22d094cd68188dd660162028b?context=explore) recently.
2. `com.ibm.icu.util.VersionInfo`, which is used by the Pellet Reasoner for ontology matching, fails on that version with the error: `java.lang.IllegalArgumentException: Invalid version number: Version number may be negative or greater than 255`
3. Subsequent calls involving `PelletReasoner` fail with a no class def error due to the failure to initialize.
4. [openJDK:8-alpine](https://hub.docker.com/layers/openjdk/library/openjdk/8-alpine/images/sha256-210ecd2595991799526a62a7099718b149e3bbefdb49764cc2a450048e0dd4c0?context=explore) uses `1.8.0_212` which is what we use for local docker testing, and is why local testing worked while deployed images did not.
