### PR TITLE
[DUOS-740][risk=no] Upgrade icu4j

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
-FROM openjdk:8-alpine
+FROM openjdk:8
+
+# Standard apt-get cleanup.
+RUN apt-get -yq autoremove && \
+    apt-get -yq clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    rm -rf /var/tmp/*
 
 COPY target/consent-ontology.jar /opt/consent-ontology.jar

--- a/pom.xml
+++ b/pom.xml
@@ -510,10 +510,21 @@
         </dependency>
 
         <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>67.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.hp.hpl.jena</groupId>
             <artifactId>jena</artifactId>
             <version>${jena.version}</version>
             <exclusions>
+                <!-- The default version included with Jena doesn't parse java version > 1.8.0_265 -->
+                <exclusion>
+                    <groupId>com.ibm.icu</groupId>
+                    <artifactId>icu4j</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-740

## Changes
* Updates the library that fails to recognize java 1.8.0_265
* Reverts the docker change in https://github.com/DataBiosphere/consent-ontology/pull/305

See also:
* https://github.com/DataBiosphere/consent-ontology/pull/304
* https://github.com/DataBiosphere/consent-ontology/pull/305