### PR TITLE
[DUOS-806][risk=low] Move trivy check to github action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,13 @@
+name: Semgrep
+on: [pull_request]
+jobs:
+  semgrep:
+    runs-on: ubuntu-18.04
+    name: Check
+    steps:
+    - uses: actions/checkout@v1
+    - name: Semgrep
+      id: semgrep
+      uses: returntocorp/semgrep-action@v1
+      with:
+        config: p/findsecbugs

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,0 +1,28 @@
+name: Trivy
+on: [pull_request]
+jobs:
+  build:
+    name: Scan for Vulnerabilities
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Maven build
+        run: |
+          sudo apt update
+          sudo apt install maven
+          mvn package -Dmaven.test.skip=true
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t docker.io/broadinstitute/consent-ontology:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/broadinstitute/consent-ontology:${{ github.sha }}'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: false
+          severity: 'CRITICAL'

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,0 @@
-# Accept the risk
-# TODO: See also https://broadinstitute.atlassian.net/browse/DUOS-806 where we will fix this permanently
-CVE-2019-20367

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:jre
+FROM adoptopenjdk:8-hotspot
 
 # Standard apt-get cleanup.
 RUN apt-get -yq autoremove && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM adoptopenjdk/openjdk8:jre
 
 # Standard apt-get cleanup.
 RUN apt-get -yq autoremove && \

--- a/build.sh
+++ b/build.sh
@@ -90,9 +90,6 @@ function docker_cmd()
         echo "Building $DOCKERHUB_REGISTRY:$HASH_TAG"
         docker build -t $DOCKERHUB_REGISTRY:${HASH_TAG} .
 
-        echo "scanning docker image..."
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$HOME"/Library/Caches:/root/.cache/ -v "$PWD/.trivyignore":/.trivyignore:ro aquasec/trivy --exit-code 1 --severity CRITICAL --ignorefile /.trivyignore "$DOCKERHUB_REGISTRY":"${HASH_TAG}"
-
         if [ $DOCKER_CMD = "push" ]; then
             echo "pushing $PROJECT docker image..."
             docker push $DOCKERHUB_REGISTRY:${HASH_TAG}


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-806
See also: 
* https://github.com/DataBiosphere/consent/pull/785
* https://github.com/DataBiosphere/consent/pull/792
* https://github.com/marketplace/actions/aqua-security-trivy
* https://github.com/returntocorp/semgrep
* https://broadworkbench.atlassian.net/browse/DSEC-132

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
