### PR TITLE
Revert "dependency: bump mockserver-netty from 5.11.1 to 5.11.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -713,7 +713,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>5.11.2</version>
+            <version>5.11.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Reverts DataBiosphere/consent-ontology#344
This update is causing flaky test runs such as https://fc-jenkins.dsp-techops.broadinstitute.org/view/Build/job/consent-ontology-build/229