### PR TITLE
[DUOS-839][risk=no] Add new data use terms publicationMoratorium and secondaryOther

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUse.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUse.java
@@ -49,6 +49,7 @@ import java.util.List;
         "collaboratorRequired",
         "geographicalRestrictions",
         "other",
+        "secondaryOther",
         "illegalBehavior",
         "addiction",
         "sexualDiseases",
@@ -61,7 +62,8 @@ import java.util.List;
         "publicationResults",
         "genomicResults",
         "genomicSummaryResults",
-        "collaborationInvestigators"
+        "collaborationInvestigators",
+        "publicationMoratorium"
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DataUse {
@@ -112,6 +114,8 @@ public class DataUse {
     private String geographicalRestrictions;
     @JsonProperty("other")
     private String other;
+    @JsonProperty("secondaryOther")
+    private String secondaryOther;
     @JsonProperty("illegalBehavior")
     private Boolean illegalBehavior;
     @JsonProperty("addiction")
@@ -138,6 +142,8 @@ public class DataUse {
     private String genomicSummaryResults;
     @JsonProperty("collaborationInvestigators")
     private Boolean collaborationInvestigators;
+    @JsonProperty("publicationMoratorium")
+    private String publicationMoratorium;
 
     @JsonProperty("generalUse")
     public Boolean getGeneralUse() {
@@ -367,6 +373,16 @@ public class DataUse {
         this.other = other;
     }
 
+    @JsonProperty("secondaryOther")
+    public String getSecondaryOther() {
+        return secondaryOther;
+    }
+
+    @JsonProperty("secondaryOther")
+    public void setSecondaryOther(String secondaryOther) {
+        this.secondaryOther = secondaryOther;
+    }
+
     @JsonProperty("illegalBehavior")
     public Boolean getIllegalBehavior() {
         return illegalBehavior;
@@ -497,6 +513,14 @@ public class DataUse {
         this.collaborationInvestigators = collaborationInvestigators;
     }
 
+    @JsonProperty("publicationMoratorium")
+    public String getPublicationMoratorium() { return publicationMoratorium; }
+
+    @JsonProperty("publicationMoratorium")
+    public void setPublicationMoratorium(String publicationMoratorium) {
+        this.publicationMoratorium = publicationMoratorium;
+    }
+
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
@@ -527,6 +551,7 @@ public class DataUse {
                 .append(collaboratorRequired)
                 .append(geographicalRestrictions)
                 .append(other)
+                .append(secondaryOther)
                 .append(illegalBehavior)
                 .append(addiction)
                 .append(sexualDiseases)
@@ -540,6 +565,7 @@ public class DataUse {
                 .append(genomicResults)
                 .append(genomicSummaryResults)
                 .append(collaborationInvestigators)
+                .append(publicationMoratorium)
                 .toHashCode();
     }
 
@@ -575,6 +601,7 @@ public class DataUse {
                 .append(collaboratorRequired, rhs.collaboratorRequired)
                 .append(geographicalRestrictions, rhs.geographicalRestrictions)
                 .append(other, rhs.other)
+                .append(secondaryOther, rhs.secondaryOther)
                 .append(illegalBehavior, rhs.illegalBehavior)
                 .append(addiction, rhs.addiction)
                 .append(sexualDiseases, rhs.sexualDiseases)
@@ -588,6 +615,7 @@ public class DataUse {
                 .append(genomicResults, rhs.genomicResults)
                 .append(genomicSummaryResults, rhs.genomicSummaryResults)
                 .append(collaborationInvestigators, rhs.collaborationInvestigators)
+                .append(publicationMoratorium, rhs.publicationMoratorium)
                 .isEquals();
     }
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseBuilder.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/model/DataUseBuilder.java
@@ -126,6 +126,11 @@ public class DataUseBuilder {
         du.setOther(other);
         return this;
     }
+
+    public DataUseBuilder setSecondaryOther(String secondaryOther) {
+        du.setSecondaryOther(secondaryOther);
+        return this;
+    }
     
     public DataUseBuilder setIllegalBehavior(Boolean illegalBehavior) {
         du.setIllegalBehavior(illegalBehavior);
@@ -189,6 +194,11 @@ public class DataUseBuilder {
 
     public DataUseBuilder setCollaborationInvestigators(Boolean collaborationInvestigators) {
         du.setCollaborationInvestigators(collaborationInvestigators);
+        return this;
+    }
+
+    public DataUseBuilder setPublicationMoratorium(String publicationMoratorium) {
+        du.setPublicationMoratorium(publicationMoratorium);
         return this;
     }
 

--- a/src/main/resources/data-use.json
+++ b/src/main/resources/data-use.json
@@ -2,7 +2,7 @@
   "id": "https://consent-ontology.dsde-prod.broadinstitute.org/schemas/data-use",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Data Use Schema",
-  "version": 1,
+  "version": 2,
   "type": "object",
   "dependencies": {
     "recontactingDataSubjects": {
@@ -91,6 +91,9 @@
     "other": {
       "type": "string"
     },
+    "secondaryOther": {
+      "type": "string"
+    },
     "cloudStorage": {
       "type": "string",
       "enum": ["Yes", "No", "Unspecified"]
@@ -142,6 +145,10 @@
     },
     "collaborationInvestigators": {
       "type": "boolean"
+    },
+    "publicationMoratorium": {
+      "type": "string",
+      "format": "date"
     }
   }
 }


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-839 and https://broadinstitute.atlassian.net/browse/DUOS-840

Adds the new data use terms publicationMoratorium and secondaryOther to the json schema and bumps the version number.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
