### PR TITLE
[DUOS-895][risk=no] Add 'X-Content-Type-Options' header to outbound responses

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
+import org.broadinstitute.dsde.consent.ontology.filters.ResponseServerFilter;
 import org.broadinstitute.dsde.consent.ontology.resources.AutocompleteResource;
 import org.broadinstitute.dsde.consent.ontology.resources.DataUseResource;
 import org.broadinstitute.dsde.consent.ontology.resources.MatchResource;
@@ -47,6 +48,7 @@ public class OntologyApp extends Application<OntologyConfiguration> {
     public void run(OntologyConfiguration config, Environment env) {
 
         Injector injector = Guice.createInjector(new OntologyModule(config, env));
+        env.jersey().register(ResponseServerFilter.class);
         env.jersey().register(injector.getInstance(AutocompleteResource.class));
         env.jersey().register(injector.getInstance(MatchResource.class));
         env.jersey().register(injector.getInstance(TranslateResource.class));

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/filters/ResponseServerFilter.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/filters/ResponseServerFilter.java
@@ -13,6 +13,7 @@ public class ResponseServerFilter implements ContainerResponseFilter {
   public void filter(
       ContainerRequestContext requestContext,
       ContainerResponseContext responseContext) throws IOException {
+    // When the no-sniff header is on the swagger-ui files, it breaks the overall UI
     if (!requestContext.getUriInfo().getPath().contains("swagger-ui")) {
       responseContext.getHeaders().add("X-Content-Type-Options", "nosniff");
     }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/filters/ResponseServerFilter.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/filters/ResponseServerFilter.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.dsde.consent.ontology.filters;
+
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ResponseServerFilter implements ContainerResponseFilter {
+
+  @Override
+  public void filter(
+      ContainerRequestContext requestContext,
+      ContainerResponseContext responseContext) throws IOException {
+    if (!requestContext.getUriInfo().getPath().contains("swagger-ui")) {
+      responseContext.getHeaders().add("X-Content-Type-Options", "nosniff");
+    }
+  }
+}


### PR DESCRIPTION
## Addresses
Ontology component to https://broadinstitute.atlassian.net/browse/DUOS-895

This adds a standard header to all outgoing requests, except for the Swagger UI code. Without that exception, the Swagger UI breaks.
See also: https://github.com/DataBiosphere/consent/pull/867

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
