### PR TITLE
[DUOS-893][risk=no] Upgrade to java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
-FROM adoptopenjdk:8-hotspot
-
-# Standard apt-get cleanup.
-RUN apt-get -yq autoremove && \
-    apt-get -yq clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/* && \
-    rm -rf /var/tmp/*
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-alpine
 
 COPY target/consent-ontology.jar /opt/consent-ontology.jar

--- a/docs/DEVNOTES.md
+++ b/docs/DEVNOTES.md
@@ -1,7 +1,7 @@
 # Local Development
 
 * Maven 3.5
-* Java 8
+* Java 11
 * Dropwizard Docs: http://www.dropwizard.io/
 
 ### Check out repository:

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <dropwizard.version>2.0.17</dropwizard.version>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <jena.version>2.6.4</jena.version>
         <jersey.version>2.19</jersey.version>
         <lucene.version>8.7.0</lucene.version>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-893

See also https://github.com/DataBiosphere/consent-ontology/pull/365
This PR should wait until #365 is merged and then rebased.

See also: https://github.com/DataBiosphere/consent/pull/875

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
