### PR TITLE
[DUOS-893][risk=no] Add Builder to Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,26 +7,6 @@
 
 ## Directory-based project format:
 .idea/
-# if you remove the above rule, at least ignore the following:
-
-# User-specific stuff:
-# .idea/workspace.xml
-# .idea/tasks.xml
-# .idea/dictionaries
-
-# Sensitive or high-churn files:
-# .idea/dataSources.ids
-# .idea/dataSources.xml
-# .idea/sqlDataSources.xml
-# .idea/dynamic.xml
-# .idea/uiDesigner.xml
-
-# Gradle:
-# .idea/gradle.xml
-# .idea/libraries
-
-# Mongo Explorer plugin:
-# .idea/mongoSettings.xml
 
 ## File-based project format:
 *.ipr
@@ -61,6 +41,8 @@ crashlytics-build.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# Build stuff
+/env.properties
 /target/
 
 # Swagger stuff that gets written on build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-alpine
+# Builder
+FROM adoptopenjdk/maven-openjdk11 AS build
 
-COPY target/consent-ontology.jar /opt/consent-ontology.jar
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+
+COPY .git /usr/src/app/.git
+COPY pom.xml /usr/src/app/pom.xml
+COPY src /usr/src/app/src
+
+RUN mvn clean package -Dmaven.test.skip=true
+
+# Published
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-alpine
+COPY --from=build /usr/src/app/target/consent-ontology.jar /opt/consent-ontology.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM adoptopenjdk/maven-openjdk11 AS build
+FROM adoptopenjdk/maven-openjdk11:latest AS build
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Addresses
https://broadworkbench.atlassian.net/browse/DUOS-893

## Changes
Added a build step to the Dockerfile so that we don't need to build the jar in the jenkins environment. The current jenkins build includes a maven step that uses java 8, so we need to do the java 11 build here before we can remove the maven step in the current build. See https://github.com/broadinstitute/dsp-jenkins/blob/master/jobs/fc-jenkins/BuildService.groovy#L87 for where we are injecting a maven step in the current build. Will be following up with a PR in that repo to remove that step once this is merged.

Build Script PR: https://github.com/broadinstitute/dsp-jenkins/pull/480
 
---- 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
