### PR TITLE
[DUOS-893][risk=no] Minor java 11 fixes

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,6 +10,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Test Report
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,10 +10,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Install
-        run: |
-          sudo apt update
-          sudo apt install maven
       - name: Test Report
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Install
         run: |
           sudo apt update
@@ -16,4 +19,5 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
+          mvn -v
           mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,4 +20,5 @@ jobs:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN
+          mvn clean jacoco:prepare-agent test jacoco:report
+          mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,10 +10,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Install
-        run: |
-          sudo apt update
-          sudo apt install maven
       - name: Package
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,6 +10,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Package
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -7,6 +7,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Install
         run: |
           sudo apt update
@@ -15,4 +18,5 @@ jobs:
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
+          mvn -v
           mvn clean package

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   build:
     name: Scan for Vulnerabilities
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -12,8 +12,6 @@ jobs:
           java-version: 11
       - name: Maven build
         run: |
-          sudo apt update
-          sudo apt install maven
           mvn -v
           mvn package -Dmaven.test.skip=true
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -10,6 +10,12 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Maven build
         run: |
           mvn -v

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -14,11 +14,9 @@ jobs:
         run: |
           mvn -v
           mvn package -Dmaven.test.skip=true
-
       - name: Build an image from Dockerfile
         run: |
           docker build -t docker.io/broadinstitute/consent-ontology:${{ github.sha }} .
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -7,11 +7,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Maven build
         run: |
           sudo apt update
           sudo apt install maven
+          mvn -v
           mvn package -Dmaven.test.skip=true
 
       - name: Build an image from Dockerfile

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
 
@@ -93,7 +92,8 @@
                 <version>2.22.2</version>
                 <configuration>
                     <!-- @{argLine} is necessary here so that that the jacoco:prepare-agent output is included for tests -->
-                    <argLine>@{argLine} -Xmx1024m</argLine>
+                    <!-- illegal-access=permit required for java 11 -->
+                    <argLine>@{argLine} -Xmx1024m --illegal-access=permit</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
                     </systemPropertyVariables>
@@ -741,6 +741,20 @@
             <groupId>org.webjars</groupId>
             <artifactId>swagger-ui</artifactId>
             <version>${swagger.ui.version}</version>
+        </dependency>
+
+        <!-- java 11 requirement -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.27.0-GA</version>
+        </dependency>
+
+        <!-- java 11 requirement -->
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>3.3.0</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,14 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
+                <!-- java 11 requirement for coveralls support-->
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>
@@ -757,13 +765,5 @@
             <version>3.3.0</version>
         </dependency>
 
-        <!-- java 11 requirement for coveralls support-->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-
     </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -757,6 +757,13 @@
             <version>3.3.0</version>
         </dependency>
 
+        <!-- java 11 requirement for coveralls support-->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-893

See also: https://github.com/DataBiosphere/consent/pull/877

## Changes
* Minor pom fixes for java 11 support
* Needed to update some of the actions that do builds as they were running java 8
  * Added caching to help speed up the builds ... they are horribly slow when pulling down maven resources
  * Removed unnecessary maven installs since it is already on the ubuntu-latest image
  * Update each one to set java 11 as the default
  * Standardize all actions on ubuntu-latest
  * Added a mvn -v for helpful debugging/run info

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
