### PR TITLE
[DUOS-791][risk=no] Support json logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,20 @@
 
     <dependencies>
 
+        <!-- Support for JSON logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+
+        <!-- Support for JSON logging -->
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.dhatim</groupId>
             <artifactId>dropwizard-sentry</artifactId>
@@ -293,13 +307,6 @@
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Address Security Vulnerability: https://broadinstitute-dsp.sourceclear.io/workspaces/jppForw/issues/vulnerabilities/28254798 -->
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
         </dependency>
 
         <dependency>

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -5,18 +5,33 @@ server:
   connector:
     type: http
     port: 8180
+  requestLog:
+    appenders:
+      - type: console
+        layout:
+          type: access-json
+
 logging:
   level: INFO
+  appenders:
+    - type: console
+      threshold: INFO
+      target: stdout
+      layout:
+        type: json
   loggers:
     "org.semanticweb": ERROR
+
 elasticSearch:
   servers:
     - localhost
   index: ontology
+
 googleStore:
   password:
   endpoint:
   bucket:
+
 storeOntology:
   bucketSubdirectory:
   configurationFileName:


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-791

Pull in the libraries and update test config to support json logging. This does not implement the logging, that has to happen in the helm chart.

Example output to STDOUT:
```
{
  "level": "INFO", 
  "logger": "io.dropwizard.jersey.DropwizardResourceConfig", 
  "message": "The following paths were found for the configured resources:

    GET     / (org.broadinstitute.dsde.consent.ontology.resources.SwaggerResource)
    GET     /autocomplete (org.broadinstitute.dsde.consent.ontology.resources.AutocompleteResource)
    POST    /match (org.broadinstitute.dsde.consent.ontology.resources.MatchResource)
    POST    /match/v1 (org.broadinstitute.dsde.consent.ontology.resources.MatchResource)
    POST    /match/v2 (org.broadinstitute.dsde.consent.ontology.resources.MatchResource)
    GET     /schemas/data-use (org.broadinstitute.dsde.consent.ontology.resources.DataUseResource)
    POST    /schemas/data-use/consent/translate (org.broadinstitute.dsde.consent.ontology.resources.DataUseResource)
    POST    /schemas/data-use/dar/translate (org.broadinstitute.dsde.consent.ontology.resources.DataUseResource)
    GET     /search (org.broadinstitute.dsde.consent.ontology.resources.OntologySearchResource)
    GET     /status (org.broadinstitute.dsde.consent.ontology.resources.StatusResource)
    GET     /swagger (org.broadinstitute.dsde.consent.ontology.resources.SwaggerResource)
    POST    /translate (org.broadinstitute.dsde.consent.ontology.resources.TranslateResource)
    POST    /translate/summary (org.broadinstitute.dsde.consent.ontology.resources.TranslateResource)
    POST    /validate/userestriction (org.broadinstitute.dsde.consent.ontology.resources.validate.ValidationResource)
    GET     /version (org.broadinstitute.dsde.consent.ontology.resources.VersionResource)
    GET     /{path:.*} (org.broadinstitute.dsde.consent.ontology.resources.SwaggerResource)
", 
  "thread": "main", 
  "timestamp": 1612977528222
}
```

---
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
