### PR TITLE
[DUOS-1041][risk=no] Handle error cases better

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheck.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheck.java
@@ -5,15 +5,13 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.inject.Inject;
 import io.dropwizard.lifecycle.Managed;
+import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
 import org.eclipse.jetty.http.HttpMethod;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
 
 public class ElasticSearchHealthCheck extends HealthCheck implements Managed {
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheck.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheck.java
@@ -61,8 +61,8 @@ public class ElasticSearchHealthCheck extends HealthCheck implements Managed {
             if (status.equalsIgnoreCase("yellow")) {
                 return Result.unhealthy("ClusterHealth is YELLOW\n" + jsonResponse.toString());
             }
-        } catch (IOException e) {
-            return Result.unhealthy(e.getMessage());
+        } catch (Throwable t) {
+            return Result.unhealthy(t.getCause().getMessage());
         }
         return Result.healthy("ClusterHealth is GREEN");
     }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
@@ -91,18 +91,20 @@ public class ElasticSearchHealthCheckTest implements WithMockServer {
         assertTrue(result.isHealthy());
     }
 
-    @Test(expected = InternalServerErrorException.class)
+    @Test
     public void testCheckDroppedConnection() {
         server.reset();
         server.when(request()).error(error().withDropConnection(true));
-        elasticSearchHealthCheck.check();
+        HealthCheck.Result result = elasticSearchHealthCheck.check();
+        assertFalse(result.isHealthy());
     }
 
-    @Test(expected = InternalServerErrorException.class)
+    @Test
     public void testErrorStatus() {
         server.reset();
         server.when(request()).respond(response().withStatusCode(500));
-        elasticSearchHealthCheck.check();
+        HealthCheck.Result result = elasticSearchHealthCheck.check();
+        assertFalse(result.isHealthy());
     }
 
 }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
@@ -1,21 +1,19 @@
 package org.broadinstitute.dsde.consent.ontology.service;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.HttpError.error;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
 import com.codahale.metrics.health.HealthCheck;
+import java.util.Collections;
 import org.broadinstitute.dsde.consent.ontology.WithMockServer;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
-
-import javax.ws.rs.InternalServerErrorException;
-import java.util.Collections;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockserver.model.HttpError.error;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
 
 public class ElasticSearchHealthCheckTest implements WithMockServer {
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1041

## Changes
Handle unknown error cases. Previous code would sometimes display parsing errors, especially in ES connectivity cases.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
