### PR TITLE
[DUOS-1073][risk=no] Use cluster, not index for health check

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheck.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheck.java
@@ -41,7 +41,7 @@ public class ElasticSearchHealthCheck extends HealthCheck implements Managed {
     @Override
     protected Result check() {
         try {
-            Request request = new Request(GET, elasticSearchSupport.getClusterHealthPath(configuration.getIndex()));
+            Request request = new Request(GET, elasticSearchSupport.getClusterHealthPath());
             Response response = elasticSearchSupport.retryRequest(client, request);
             if (response.getStatusLine().getStatusCode() != 200) {
                 return Result.unhealthy(response.getStatusLine().getReasonPhrase());

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
@@ -62,8 +62,8 @@ class ElasticSearchSupport {
         return getTermPath(index) + "/_search";
     }
 
-    String getClusterHealthPath(String index) {
-        return "/_cluster/health/" + index;
+    String getClusterHealthPath() {
+        return "/_cluster/health";
     }
 
     /**

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupportTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupportTest.java
@@ -41,7 +41,7 @@ public class ElasticSearchSupportTest {
 
     @Test
     public void testGetClusterHealthPath() {
-        String path = elasticSearchSupport.getClusterHealthPath(configuration.getIndex());
+        String path = elasticSearchSupport.getClusterHealthPath();
         Assert.assertNotNull(path);
         Assert.assertTrue(path.contains(configuration.getIndex()));
         Assert.assertTrue(path.contains("health"));

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupportTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupportTest.java
@@ -43,7 +43,6 @@ public class ElasticSearchSupportTest {
     public void testGetClusterHealthPath() {
         String path = elasticSearchSupport.getClusterHealthPath();
         Assert.assertNotNull(path);
-        Assert.assertTrue(path.contains(configuration.getIndex()));
         Assert.assertTrue(path.contains("health"));
     }
 


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1073

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/DataBiosphere/consent-ontology/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
- [ ] I've updated Swagger to reflect any API changes

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
