### PR TITLE
[DUOS-1258][risk=no] Use mockserver in org.testcontainer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <jena.version>2.6.4</jena.version>
         <jersey.version>2.19</jersey.version>
         <lucene.version>8.8.2</lucene.version>
+        <mockserver.version>5.11.2</mockserver.version>
         <owl.version>5.1.17</owl.version>
         <pellet.version>2.3.6-ansell</pellet.version>
         <rdf4j-rio.version>3.7.0</rdf4j-rio.version>
@@ -738,26 +739,20 @@
             <version>1.10.19</version>
         </dependency>
 
-        <!-- Required for mocking ontology and elastic search responses -->
+        <!-- Required for mocking elastic search responses -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mockserver</artifactId>
+            <version>1.15.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Required for mocking client calls against elastic search -->
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>5.11.2</version>
+            <artifactId>mockserver-client-java</artifactId>
+            <version>${mockserver.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <!--
-                  The following clashes with jakarta.validation:jakarta.validation-api and
-                  prevents configurations from loading when running locally
-                -->
-                <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/configurations/ElasticSearchConfiguration.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/configurations/ElasticSearchConfiguration.java
@@ -11,6 +11,11 @@ public class ElasticSearchConfiguration {
     @NotNull
     public String index;
 
+    /**
+     * This is configurable for testing purposes
+     */
+    private int port = 9200;
+
     public List<String> getServers() {
         return servers;
     }
@@ -25,5 +30,13 @@ public class ElasticSearchConfiguration {
 
     public void setIndex(String index) {
         this.index = index;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
     }
 }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
@@ -41,7 +41,7 @@ class ElasticSearchSupport {
         HttpHost[] hosts = configuration
                 .getServers()
                 .stream()
-                .map(server -> new HttpHost(server, 9200, "http"))
+                .map(server -> new HttpHost(server, configuration.getPort(), "http"))
                 .collect(Collectors.toList())
                 .toArray(new HttpHost[configuration.getServers().size()]);
         return RestClient

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/WithMockServer.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/WithMockServer.java
@@ -10,6 +10,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public interface WithMockServer {
 
+    Logger log = Utils.getLogger(WithMockServer.class);
     DockerImageName IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-" + getMockServerVersion());
 
     default void stop(MockServerContainer container) {
@@ -19,18 +20,18 @@ public interface WithMockServer {
     }
 
     static String getMockServerVersion() {
-        Logger log = Utils.getLogger(WithMockServer.class);
         String version = "5.11.2";
+        String versionPropName = "mockserver.version";
         try (InputStream is = WithMockServer.class.getResourceAsStream("/mvn.properties")) {
             Properties p = new Properties();
             p.load(is);
-            if (StringUtils.isNotEmpty(p.getProperty("mockserver.version"))) {
-                version = p.getProperty("mockserver.version");
+            if (StringUtils.isNotEmpty(p.getProperty(versionPropName))) {
+                version = p.getProperty(versionPropName);
             } else {
-                log.warn("swagger.ui.path is not configured correctly, defaulting to: " + version);
+                log.warn(versionPropName + " is not configured correctly, defaulting to: " + version);
             }
         } catch (Exception e) {
-            log.warn(e.getMessage());
+            log.error(e.getMessage());
             log.warn("Defaulting to: " + version);
         }
         return version;

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/WithMockServer.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/WithMockServer.java
@@ -1,20 +1,39 @@
 package org.broadinstitute.dsde.consent.ontology;
 
-import org.mockserver.integration.ClientAndServer;
-
-import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public interface WithMockServer {
 
-    default ClientAndServer startMockServer(int port) {
-        // Force mock server logging
-        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
-                .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
-                .setLevel(ch.qos.logback.classic.Level.OFF);
-        ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
-                .getLogger("org.mockserver"))
-                .setLevel(ch.qos.logback.classic.Level.OFF);
-        return startClientAndServer(port);
+    DockerImageName IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-" + getMockServerVersion());
+
+    default void stop(MockServerContainer container) {
+        if (Objects.nonNull(container) && container.isRunning()) {
+            container.stop();
+        }
+    }
+
+    static String getMockServerVersion() {
+        Logger log = Utils.getLogger(WithMockServer.class);
+        String version = "5.11.2";
+        try (InputStream is = WithMockServer.class.getResourceAsStream("/mvn.properties")) {
+            Properties p = new Properties();
+            p.load(is);
+            if (StringUtils.isNotEmpty(p.getProperty("mockserver.version"))) {
+                version = p.getProperty("mockserver.version");
+            } else {
+                log.warn("swagger.ui.path is not configured correctly, defaulting to: " + version);
+            }
+        } catch (Exception e) {
+            log.warn(e.getMessage());
+            log.warn("Defaulting to: " + version);
+        }
+        return version;
     }
 
 }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
@@ -6,6 +6,7 @@ import static org.mockserver.model.HttpError.error;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import com.google.api.client.http.HttpStatusCodes;
 import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.BadRequestException;
@@ -56,7 +57,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
     @Test
     public void testRetrySuccessAfterOneFailure() {
         mockServerClient.when(request(), Times.exactly(1)).error(error().withDropConnection(true));
-        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup("cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -65,7 +66,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
     @Test
     public void testRetrySuccessAfterTwoFailures() {
         mockServerClient.when(request(), Times.exactly(2)).error(error().withDropConnection(true));
-        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup("cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -74,7 +75,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
     @Test(expected = InternalServerErrorException.class)
     public void testRetryFailureAfterThreeFailures() {
         mockServerClient.when(request(), Times.exactly(3)).error(error().withDropConnection(true));
-        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).withBody(cancerJson));
         autocompleteAPI.lookup("cancer", 1);
     }
 
@@ -86,19 +87,19 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test(expected = BadRequestException.class)
     public void testBadRequest() {
-        mockServerClient.when(request()).respond(response().withStatusCode(400));
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST));
         autocompleteAPI.lookup("cancer", 1);
     }
 
     @Test(expected = NotFoundException.class)
     public void testNotFound() {
-        mockServerClient.when(request()).respond(response().withStatusCode(404));
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND));
         autocompleteAPI.lookup("cancer", 1);
     }
 
     @Test(expected = BadRequestException.class)
     public void testInvalidIdStringError() {
-        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).withBody(cancerJson));
         when(elasticSearchSupport.getEncodedEndpoint(any(), any())).thenThrow(new BadRequestException());
         autocompleteAPI.setElasticSearchSupport(elasticSearchSupport);
         autocompleteAPI.lookupById("cancer");
@@ -106,7 +107,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test
     public void testLookup() {
-        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup("cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -114,7 +115,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test
     public void testLookupWithTags() {
-        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup(Collections.singletonList("tag"), "cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -122,7 +123,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test
     public void  testLookupById() {
-        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerGetJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).withBody(cancerGetJson));
         List<TermResource> termResource = autocompleteAPI.lookupById("http://purl.obolibrary.org/obo/DOID_162");
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
@@ -25,7 +25,6 @@ import org.mockserver.client.MockServerClient;
 import org.mockserver.matchers.Times;
 import org.testcontainers.containers.MockServerContainer;
 
-@SuppressWarnings("FieldCanBeLocal")
 public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     private ElasticSearchAutocomplete autocompleteAPI;
@@ -130,7 +129,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
     }
 
     // mock response for a search
-    private static String cancerJson = "{\n" +
+    private static final String cancerJson = "{\n" +
         "  \"took\": 15,\n" +
         "  \"timed_out\": false,\n" +
         "  \"_shards\": {\n" +
@@ -175,7 +174,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
         "}";
 
     // mock response for a document get-by-id
-    private static String cancerGetJson = "{\n" +
+    private static final String cancerGetJson = "{\n" +
             "  \"_index\": \"ontology\",\n" +
             "  \"_type\": \"ontology_term\",\n" +
             "  \"_id\": \"http://purl.obolibrary.org/obo/DOID_162\",\n" +

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchAutocompleteTest.java
@@ -1,36 +1,39 @@
 package org.broadinstitute.dsde.consent.ontology.service;
 
-import org.broadinstitute.dsde.consent.ontology.WithMockServer;
-import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
-import org.broadinstitute.dsde.consent.ontology.model.TermResource;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockserver.integration.ClientAndServer;
-import org.mockserver.matchers.Times;
-import org.mockserver.model.HttpResponse;
-
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotFoundException;
-import java.util.Collections;
-import java.util.List;
-
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockserver.model.HttpError.error;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+import java.util.Collections;
+import java.util.List;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
+import org.broadinstitute.dsde.consent.ontology.WithMockServer;
+import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
+import org.broadinstitute.dsde.consent.ontology.model.TermResource;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.matchers.Times;
+import org.testcontainers.containers.MockServerContainer;
+
 @SuppressWarnings("FieldCanBeLocal")
 public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     private ElasticSearchAutocomplete autocompleteAPI;
+    private MockServerClient mockServerClient;
     private static final String INDEX_NAME = "local-ontology";
-    private ClientAndServer server;
+
+    @Rule
+    public MockServerContainer container = new MockServerContainer(IMAGE);
 
     @Mock
     ElasticSearchSupport elasticSearchSupport;
@@ -40,28 +43,21 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
         MockitoAnnotations.initMocks(this);
         ElasticSearchConfiguration configuration = new ElasticSearchConfiguration();
         configuration.setIndex(INDEX_NAME);
-        configuration.setServers(Collections.singletonList("localhost"));
+        configuration.setServers(Collections.singletonList(container.getHost()));
+        configuration.setPort(container.getServerPort());
         autocompleteAPI = new ElasticSearchAutocomplete(configuration);
-        server = startMockServer(9200);
+        mockServerClient = new MockServerClient(container.getHost(), container.getServerPort());
     }
 
     @After
     public void shutDown() {
-        if (server != null && server.isRunning()) {
-            server.stop();
-        }
-    }
-
-    private void mockResponse(HttpResponse response) {
-        server.reset();
-        server.when(request()).respond(response);
+        stop(container);
     }
 
     @Test
     public void testRetrySuccessAfterOneFailure() {
-        server.reset();
-        server.when(request(), Times.exactly(1)).error(error().withDropConnection(true));
-        server.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request(), Times.exactly(1)).error(error().withDropConnection(true));
+        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup("cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -69,9 +65,8 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test
     public void testRetrySuccessAfterTwoFailures() {
-        server.reset();
-        server.when(request(), Times.exactly(2)).error(error().withDropConnection(true));
-        server.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request(), Times.exactly(2)).error(error().withDropConnection(true));
+        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup("cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -79,34 +74,32 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test(expected = InternalServerErrorException.class)
     public void testRetryFailureAfterThreeFailures() {
-        server.reset();
-        server.when(request(), Times.exactly(3)).error(error().withDropConnection(true));
-        server.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request(), Times.exactly(3)).error(error().withDropConnection(true));
+        mockServerClient.when(request(), Times.exactly(1)).respond(response().withStatusCode(200).withBody(cancerJson));
         autocompleteAPI.lookup("cancer", 1);
     }
 
     @Test(expected = InternalServerErrorException.class)
     public void testRetryFailure() {
-        server.reset();
-        server.when(request()).error(error().withDropConnection(true));
+        mockServerClient.when(request()).error(error().withDropConnection(true));
         autocompleteAPI.lookup("cancer", 1);
     }
 
     @Test(expected = BadRequestException.class)
     public void testBadRequest() {
-        mockResponse(response().withStatusCode(400));
+        mockServerClient.when(request()).respond(response().withStatusCode(400));
         autocompleteAPI.lookup("cancer", 1);
     }
 
     @Test(expected = NotFoundException.class)
     public void testNotFound() {
-        mockResponse(response().withStatusCode(404));
+        mockServerClient.when(request()).respond(response().withStatusCode(404));
         autocompleteAPI.lookup("cancer", 1);
     }
 
     @Test(expected = BadRequestException.class)
     public void testInvalidIdStringError() {
-        mockResponse(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerJson));
         when(elasticSearchSupport.getEncodedEndpoint(any(), any())).thenThrow(new BadRequestException());
         autocompleteAPI.setElasticSearchSupport(elasticSearchSupport);
         autocompleteAPI.lookupById("cancer");
@@ -114,7 +107,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test
     public void testLookup() {
-        mockResponse(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup("cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -122,7 +115,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test
     public void testLookupWithTags() {
-        mockResponse(response().withStatusCode(200).withBody(cancerJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerJson));
         List<TermResource> termResource = autocompleteAPI.lookup(Collections.singletonList("tag"), "cancer", 1);
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));
@@ -130,7 +123,7 @@ public class ElasticSearchAutocompleteTest implements WithMockServer {
 
     @Test
     public void  testLookupById() {
-        mockResponse(response().withStatusCode(200).withBody(cancerGetJson));
+        mockServerClient.when(request()).respond(response().withStatusCode(200).withBody(cancerGetJson));
         List<TermResource> termResource = autocompleteAPI.lookupById("http://purl.obolibrary.org/obo/DOID_162");
         Assert.assertEquals(1, termResource.size());
         Assert.assertTrue(termResource.get(0).getSynonyms().contains("primary cancer"));

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchHealthCheckTest.java
@@ -7,6 +7,7 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 import com.codahale.metrics.health.HealthCheck;
+import com.google.api.client.http.HttpStatusCodes;
 import java.util.Collections;
 import org.broadinstitute.dsde.consent.ontology.WithMockServer;
 import org.broadinstitute.dsde.consent.ontology.configurations.ElasticSearchConfiguration;
@@ -41,7 +42,7 @@ public class ElasticSearchHealthCheckTest implements WithMockServer {
     }
 
     private void mockRequest(String color, Boolean timedOut) {
-        mockServerClient.when(request()).respond(response().withStatusCode(200).
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_OK).
             withBody("{\n" +
                 "  \"cluster_name\": \"docker-cluster\",\n" +
                 "  \"status\": \"" + color + "\",\n" +
@@ -101,7 +102,7 @@ public class ElasticSearchHealthCheckTest implements WithMockServer {
 
     @Test
     public void testErrorStatus() {
-        mockServerClient.when(request()).respond(response().withStatusCode(500));
+        mockServerClient.when(request()).respond(response().withStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR));
         HealthCheck.Result result = elasticSearchHealthCheck.check();
         assertFalse(result.isHealthy());
     }

--- a/src/test/resources/mvn.properties
+++ b/src/test/resources/mvn.properties
@@ -1,2 +1,3 @@
 #Properties
 swagger.ui.path=${swagger.ui.path}
+mockserver.version=${mockserver.version}


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1258

## Changes
See also: https://github.com/DataBiosphere/consent/pull/1071

Tests that use mockserver are failing frequently in github test environments. This changes them to use a mockserver test container instead which has been more stable in consent.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
