### PR TITLE
[DUOS-256][risk=no] Add build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,79 @@
+name: Tag, Build and Push Image
+
+on:
+  push:
+    branches:
+    - develop
+    paths-ignore:
+    - 'README.md'
+    - '.github/**'
+  pull_request:
+    branches:
+    - develop
+    paths-ignore:
+    - 'README.md'
+env:
+  REGISTRY_HOST: gcr.io
+  GOOGLE_PROJECT: broad-dsp-gcr-public
+  SERVICE_NAME: ${{ github.event.repository.name }}
+jobs:
+  tag-build-push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Get Short Sha
+      id: short-sha
+      run: echo "::set-output name=sha::$(git rev-parse --short=12 HEAD)"
+    - name: Auth to GCR
+      uses: google-github-actions/setup-gcloud@master
+      with:
+        version: '270.0.0'
+        service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
+        service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+    - name: Auth Docker for GCR
+      run: gcloud auth configure-docker --quiet
+    - name: Construct tags
+      id: construct-tags
+      run: |
+        SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.short-sha.outputs.sha }}"
+        ENVIRONMENT_TAG=""
+        if ${{ github.event_name == 'pull_request'}}; then
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${{ steps.short-sha.outputs.sha }}"
+        elif ${{github.event_name == 'push' }}; then
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
+        fi
+        echo ::set-output name=sha-tag::$SHA_TAG
+        echo ::set-output name=environment-tag::$ENVIRONMENT_TAG
+    - name: Build Image
+      run: |
+        docker build \
+        -t ${{ steps.construct-tags.outputs.sha-tag }} \
+        -t ${{ steps.construct-tags.outputs.environment-tag }} \
+        .
+    - name: Log Github Actor
+      run: echo "${{ github.actor }}"
+    - name: Push Image to GCR
+      if: github.actor != 'dependabot[bot]'
+      run: |
+        docker push ${{ steps.construct-tags.outputs.sha-tag }}
+        docker push ${{ steps.construct-tags.outputs.environment-tag }}
+    - name: Dispatch to terra-helmfile
+      if: github.event_name == 'push'
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "ontology", "version": "${{ steps.short-sha.outputs.sha }}", "dev_only": false}'
+    - name: Notify Slack
+      # only notify for develop branch build
+      if: github.event_name == 'push'
+      uses: broadinstitute/action-slack@v3.8.0
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        status: ${{ job.status }}
+        channel: "#duos-notifications"
+        fields: repo,commit,author,action,eventName,ref,workflow,job,took

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,12 +6,14 @@ on:
     - develop
     paths-ignore:
     - 'README.md'
+    - 'LICENSE.txt'
     - '.github/**'
   pull_request:
     branches:
     - develop
     paths-ignore:
     - 'README.md'
+    - 'LICENSE.txt'
 env:
   REGISTRY_HOST: gcr.io
   GOOGLE_PROJECT: broad-dsp-gcr-public


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-256

* Adds new build action using secrets pushed from TF
* ~Requires https://github.com/broadinstitute/terraform-ap-deployments/pull/455~ Done
* Requires disabling the image build/push/gke-deploy portions of the [consent-ontology-build](https://fc-jenkins.dsp-techops.broadinstitute.org/view/Build/job/consent-ontology-build/) jenkins job just prior to merging
* See also: 
  * https://github.com/DataBiosphere/consent/pull/1329
  * https://github.com/DataBiosphere/duos-ui/blob/develop/.github/workflows/build.yaml

## Action Results:
<img width="869" alt="Screen Shot 2021-10-28 at 11 32 04 AM" src="https://user-images.githubusercontent.com/116679/139288360-e062009a-70bc-4781-83b5-a2708ca5a421.png">

## GCR image with tags:
<img width="1235" alt="Screen Shot 2021-10-28 at 11 32 22 AM" src="https://user-images.githubusercontent.com/116679/139288395-3baaec5e-aa9f-4afa-8727-61718584173d.png">


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
