### PR TITLE
[DUOS-1476][risk=no] Don't ignore files on image build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,16 +4,9 @@ on:
   push:
     branches:
     - develop
-    paths-ignore:
-    - 'README.md'
-    - 'LICENSE.txt'
-    - '.github/**'
   pull_request:
     branches:
     - develop
-    paths-ignore:
-    - 'README.md'
-    - 'LICENSE.txt'
 env:
   REGISTRY_HOST: gcr.io
   GOOGLE_PROJECT: broad-dsp-gcr-public


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-1476

We were sometimes not pushing an image if there were no real code changes. We want to make sure every merge to develop is reflected in an image in GCR.

See also: https://github.com/DataBiosphere/duos-ui/pull/1342
See also: https://github.com/DataBiosphere/consent/pull/1338

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
