### PR TITLE
[DUOS-1503][risk=no] Update builder to a non-deprecated image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Builder
-FROM adoptopenjdk/maven-openjdk11:latest AS build
+FROM eclipse-temurin:11-jdk-alpine AS build
 
-RUN mkdir /usr/src/app
+RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY .git /usr/src/app/.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM eclipse-temurin:11-jdk-alpine AS build
+FROM maven:3.8.3-eclipse-temurin-11 AS build
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1503

The existing build image is deprecated: https://hub.docker.com/_/adoptopenjdk
See also: https://github.com/DataBiosphere/consent/pull/1339

Manually ran automation tests 👍🏽 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
