### PR TITLE
[DUOS-1421][risk=no] Update status format

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
@@ -3,7 +3,11 @@ package org.broadinstitute.dsde.consent.ontology.resources;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.Inject;
+import java.util.LinkedHashMap;
+import org.broadinstitute.dsde.consent.ontology.OntologyApp;
 import org.broadinstitute.dsde.consent.ontology.Utils;
+import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
+import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchHealthCheck;
 import org.slf4j.Logger;
 
 import javax.ws.rs.GET;
@@ -15,9 +19,13 @@ import java.util.Map;
 @Path("status")
 public class StatusResource {
 
+    public static final String OK = "ok";
+    public static final String DEGRADED = "degraded";
+    public static final String SYSTEMS = "systems";
+
     private final Logger log = Utils.getLogger(this.getClass());
 
-    private HealthCheckRegistry healthChecks;
+    private final HealthCheckRegistry healthChecks;
 
     @Inject
     public StatusResource(HealthCheckRegistry healthChecks) {
@@ -33,9 +41,22 @@ public class StatusResource {
                 stream().
                 filter(e -> !e.getValue().isHealthy()).
                 forEach(e -> log.warn("Error in service " + e.getKey() + ": " + formatResultError(e.getValue())));
-        return Response.ok(results).build();
+        return Response.ok(formatResults(results)).build();
     }
 
+    private Map<String, Object> formatResults(Map<String, HealthCheck.Result> results) {
+        // Order is important. Put Ok and Degraded states at the beginning of the map and
+        // add all other entries after that.
+        Map<String, Object> formattedResults = new LinkedHashMap<>();
+        formattedResults.put(OK, true);
+        HealthCheck.Result gcs = results.getOrDefault(GCSHealthCheck.NAME, HealthCheck.Result.unhealthy("Unable to access GCS"));
+        HealthCheck.Result elasticSearch = results.getOrDefault(ElasticSearchHealthCheck.NAME, HealthCheck.Result.unhealthy("Unable to access ElasticSearch"));
+        boolean degraded = (!gcs.isHealthy() || !elasticSearch.isHealthy());
+        formattedResults.put(DEGRADED, degraded);
+        formattedResults.put(SYSTEMS, results);
+        return formattedResults;
+    }
+    
     private String formatResultError(HealthCheck.Result result) {
         if (result.getMessage() != null) {
             return result.getMessage();

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
@@ -4,17 +4,15 @@ import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.Inject;
 import java.util.LinkedHashMap;
-import org.broadinstitute.dsde.consent.ontology.OntologyApp;
-import org.broadinstitute.dsde.consent.ontology.Utils;
-import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
-import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchHealthCheck;
-import org.slf4j.Logger;
-
+import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.Map;
+import org.broadinstitute.dsde.consent.ontology.Utils;
+import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
+import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchHealthCheck;
+import org.slf4j.Logger;
 
 @Path("status")
 public class StatusResource {
@@ -36,7 +34,7 @@ public class StatusResource {
     @Produces("application/json")
     public Response getStatus() {
         Map<String, HealthCheck.Result> results = healthChecks.runHealthChecks();
-        // Ontology can work in a degraded status so log errors at the warning level.
+        // Log errors at the warning level for follow-up
         results.entrySet().
                 stream().
                 filter(e -> !e.getValue().isHealthy()).
@@ -48,6 +46,7 @@ public class StatusResource {
         // Order is important. Put Ok and Degraded states at the beginning of the map and
         // add all other entries after that.
         Map<String, Object> formattedResults = new LinkedHashMap<>();
+        // Ontology can still work in a degraded status
         formattedResults.put(OK, true);
         HealthCheck.Result gcs = results.getOrDefault(GCSHealthCheck.NAME, HealthCheck.Result.unhealthy("Unable to access GCS"));
         HealthCheck.Result elasticSearch = results.getOrDefault(ElasticSearchHealthCheck.NAME, HealthCheck.Result.unhealthy("Unable to access ElasticSearch"));


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1421

Minor change to the status formatting. Should not affect fiabs or consent.

## Before
```
{
  "deadlocks": {
    "details": null, 
    "duration": 0, 
    "error": null, 
    "healthy": true, 
    "message": null, 
    "time": 1636467204776, 
    "timestamp": "2021-11-09T14:13:24.776Z"
  }, 
  "elastic-search": {
    "details": null, 
    "duration": 1, 
    "error": null, 
    "healthy": true, 
    "message": "ClusterHealth is GREEN", 
    "time": 1636467204756, 
    "timestamp": "2021-11-09T14:13:24.756Z"
  }, 
  "google-cloud-storage": {
    "details": null, 
    "duration": 19, 
    "error": null, 
    "healthy": true, 
    "message": null, 
    "time": 1636467204776, 
    "timestamp": "2021-11-09T14:13:24.776Z"
  }
}
```

## After
```
{
  "ok": true, 
  "degraded": true, 
  "systems": {
    "deadlocks": {
      "details": null, 
      "duration": 1, 
      "error": null, 
      "healthy": true, 
      "message": null, 
      "time": 1636466196583, 
      "timestamp": "2021-11-09T13:56:36.583Z"
    }, 
    "elastic-search": {
      "details": null, 
      "duration": 6774, 
      "error": null, 
      "healthy": false, 
      "message": "Retrying failed to complete successfully after 3 attempts.", 
      "time": 1636466195279, 
      "timestamp": "2021-11-09T13:56:35.279Z"
    }, 
    "google-cloud-storage": {
      "details": null, 
      "duration": 1302, 
      "error": null, 
      "healthy": true, 
      "message": null, 
      "time": 1636466196582, 
      "timestamp": "2021-11-09T13:56:36.582Z"
    }
  }
}
```

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
