### PR TITLE
[DUOS-1593][risk=no]ontology-endpoint-for-finding-multiple-doid-terms

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
@@ -11,8 +11,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -33,12 +31,12 @@ public class OntologySearchResource {
     public Response getOntologyById(@QueryParam("id") @DefaultValue("") String queryTerm) {
         if (queryTerm.isBlank()) {
             return Response
-                    .status(Response.Status.BAD_REQUEST.getStatusCode(), "Ontology ID term cannot be empty.")
+                    .status(Response.Status.BAD_REQUEST)
+                    .entity(new ErrorResponse("Ontology ID term cannot be empty.", Response.Status.BAD_REQUEST.getStatusCode()))
                     .build();
         }
 
         String[] queries = queryTerm.split(",");
-
         try {
             List<TermResource> results = new Streams.FailableStream<>(Arrays.stream(queries))
                     .filter(Objects::nonNull)
@@ -49,8 +47,8 @@ public class OntologySearchResource {
                     .collect(Collectors.toList());
             return checkOntologyRetrieval(results);
         } catch (Exception e) {
-            return Response
-                    .status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Ontology could not be successfully retrieved.")
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(new ErrorResponse("Ontology could not be successfully retrieved.", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
                     .build();
         }
 
@@ -58,8 +56,8 @@ public class OntologySearchResource {
 
     private Response checkOntologyRetrieval(List<TermResource> results) {
         if (results.isEmpty()) {
-            return Response
-                    .status(Response.Status.NOT_FOUND.getStatusCode(), "Supplied IDs do not match any known ontology.")
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(new ErrorResponse("Supplied IDs do not match any known ontologies.", Response.Status.NOT_FOUND.getStatusCode()))
                     .build();
         } else {
             return Response.ok().entity(results).build();

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Path("/search")
 public class OntologySearchResource {
 
-    private AutocompleteService service;
+    private final AutocompleteService service;
 
     @Inject
     public OntologySearchResource(AutocompleteService service) {

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
@@ -159,11 +159,19 @@ class ElasticSearchSupport {
     }
 
     String getEncodedEndpoint(String query, String index) {
+        String queryUrl = convertQueryToUrl(query);
         try {
-            return getTermPath(index) + "/" + java.net.URLEncoder.encode(query, "UTF-8");
+            return getTermPath(index) + "/" + java.net.URLEncoder.encode(queryUrl, "UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new BadRequestException(e);
         }
+    }
+
+    private String convertQueryToUrl(String query) {
+        if (query.substring(0, 4).equals("DOID")) {
+            return "http://purl.obolibrary.org/obo/" + query;
+        }
+        return query;
     }
 
 }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResourceTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResourceTest.java
@@ -1,13 +1,13 @@
 package org.broadinstitute.dsde.consent.ontology.resources;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.core.Response;
+
 import org.broadinstitute.dsde.consent.ontology.model.TermResource;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
 import org.junit.Before;
@@ -42,7 +42,7 @@ public class OntologySearchResourceTest {
         Response response = resource.getOntologyById("");
         assertEquals(400, response.getStatus());
         ErrorResponse error = (ErrorResponse) response.getEntity();
-        assertEquals(" Ontology ID term cannot be empty. ", error.getMessage());
+        assertEquals("Ontology ID term cannot be empty.", error.getMessage());
         verify(autocompleteService, times(0)).lookupById(Mockito.anyString());
     }
 
@@ -51,7 +51,7 @@ public class OntologySearchResourceTest {
         Response response = resource.getOntologyById("DOID_404");
         assertEquals(404, response.getStatus());
         ErrorResponse error = (ErrorResponse) response.getEntity();
-        assertEquals(" Supplied ID doesn't match any known ontology. ", error.getMessage());
+        assertEquals("Supplied IDs do not match any known ontologies.", error.getMessage());
         verify(autocompleteService, times(1)).lookupById("DOID_404");
     }
 
@@ -66,6 +66,45 @@ public class OntologySearchResourceTest {
         assertEquals("Some label", terms.get(0).label);
         assertEquals("Some definition", terms.get(0).definition);
         verify(autocompleteService, times(1)).lookupById("DOID_4");
+    }
+
+    @Test
+    public void testGetByIdMultiple() throws Exception {
+        Response response = resource.getOntologyById("DOID_4,DOID_5,DOID_6");
+        assertEquals(200, response.getStatus());
+        verify(autocompleteService, times(3)).lookupById(Mockito.anyString());
+    }
+
+    @Test
+    public void testGetByIdMultipleEmpty() throws Exception {
+        Response response = resource.getOntologyById(",,,");
+        assertEquals(404, response.getStatus());
+        ErrorResponse error = (ErrorResponse) response.getEntity();
+        assertEquals("Supplied IDs do not match any known ontologies.", error.getMessage());
+        verify(autocompleteService, times(0)).lookupById(Mockito.anyString());
+    }
+
+    @Test
+    public void testGetByIdMultipleNotFound() throws Exception {
+        Response response = resource.getOntologyById(",DOID_404,");
+        assertEquals(404, response.getStatus());
+        ErrorResponse error = (ErrorResponse) response.getEntity();
+        assertEquals("Supplied IDs do not match any known ontologies.", error.getMessage());
+        verify(autocompleteService, times(1)).lookupById("DOID_404");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetByIdSomeFound() throws Exception {
+        Response response = resource.getOntologyById(",DOID_3,,DOID_4");
+        assertEquals(200, response.getStatus());
+        List<TermResource> terms = (List<TermResource>) response.getEntity();
+        assertEquals(1, terms.size());
+        assertEquals("DOID_4", terms.get(0).id);
+        assertEquals("Some label", terms.get(0).label);
+        assertEquals("Some definition", terms.get(0).definition);
+        verify(autocompleteService, times(1)).lookupById("DOID_4");
+        verify(autocompleteService, times(2)).lookupById(Mockito.anyString());
     }
 
 }


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1593)
Summary of changes:

- Allow search GET request to handle a variable number of DOIDs in a single request
- Allow query terms to be in url or DOID_# form 

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
