### PR TITLE
[no-ticket][risk=no] Update reviewers to team instead of individuals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,30 @@
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  target-branch: develop
-  reviewers:
-  - rushtong
-  - JVThomas
-  assignees:
-  - rushtong
-  - JVThomas
-  labels:
-  - dependency
-  commit-message:
-    prefix: dependency
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  target-branch: develop
-  reviewers:
-  - rushtong
-  assignees:
-  - rushtong
-  labels:
-  - dependency
-  ignore:
-  - dependency-name: adoptopenjdk
-    versions:
-    - "> 8.pre.hotspot"
-  - dependency-name: broad-dsp-gcr-public/base/jre
-    versions:
-    - ">= 15.pre.alpine.a, < 16"
-  - dependency-name: openjdk
-    versions:
-    - "> 8"
-  commit-message:
-    prefix: dependency
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    target-branch: develop
+    reviewers:
+      - "@DataBiosphere/DUOS"
+    labels:
+      - dependency
+    commit-message:
+      prefix: dependency
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    target-branch: develop
+    reviewers:
+      - "@DataBiosphere/DUOS"
+    labels:
+      - dependency
+    ignore:
+      - dependency-name: broad-dsp-gcr-public/base/jre
+        versions:
+          - ">= 15.pre.alpine.a, < 16"
+    commit-message:
+      prefix: dependency


### PR DESCRIPTION
Minor update to the default assignee/reviewers for all PRs to this repo

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
