### PR TITLE
[No ticket] Update Google Branch reference in Build Action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       id: short-sha
       run: echo "::set-output name=sha::$(git rev-parse --short=12 HEAD)"
     - name: Auth to GCR
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}


### PR DESCRIPTION
PR updates referenced google branch in the Github Build action due to scheduled name change from master to main on 2022-04-05

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
