### PR TITLE
[DUOS-1583][risk=no] Java 17 Updates

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Run Report
         run: |
           mvn -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM maven:3.8.3-eclipse-temurin-11 AS build
+FROM maven:3.8.3-eclipse-temurin-17 AS build
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -11,5 +11,5 @@ COPY src /usr/src/app/src
 RUN mvn clean package -Dmaven.test.skip=true
 
 # Published
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 COPY --from=build /usr/src/app/target/consent-ontology.jar /opt/consent-ontology.jar

--- a/docs/DEVNOTES.md
+++ b/docs/DEVNOTES.md
@@ -1,7 +1,7 @@
 # Local Development
 
-* Maven 3.5
-* Java 11
+* Maven 3.8
+* Java 17
 * Dropwizard Docs: http://www.dropwizard.io/
 
 ### Check out repository:
@@ -21,17 +21,13 @@ Ensure that your test environment supports that.
 
 #### Docker
 
-Consent-Ontology is packaged into a docker image that is stored in [Consent-Ontology Dockerhub Repo](https://hub.docker.com/r/broadinstitute/consent-ontology).
+Consent-Ontology is packaged into a docker image that is stored in GCR: `gcr.io/broad-dsp-gcr-public/consent-ontology`
 ```
-# to build the image
-./build.sh -d build
-
-# to build the image and push to dockerhub
-./build.sh -d push
-
-# to pull the image from dockerhub
-docker pull broadinstitute/consent-ontology
+# build the docker image
+docker build . -t ontology
 ```
+
+This image can then be run with the proper configuration files provided.
 
 ### Render Configs 
 Specific to internal Broad systems:
@@ -54,14 +50,11 @@ java -jar /path/to/consent-ontology.jar server /path/to/config/file
 Visit local swagger page: https://local.broadinstitute.org:28443/swagger/
 
 ### Debugging
-Port 5005 is open in the configured docker compose. 
+Port 7777 is open in the configured docker compose. 
 Set up a remote debug configuration pointing to `local.broadinstitute.org`
 and the defaults should be correct.
 
-Execute the `fizzed-watcher:run` maven task (under consent plugins) 
-to enable hot reloading of class and resource files.
-
-### Developing with a local Elastic Search instance:
+### Developing with a local ElasticSearch instance:
 
 Update the compose file to include a new section for an ES instance:
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <dropwizard.version>2.1.1</dropwizard.version>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <jena.version>2.6.4</jena.version>
         <jersey.version>2.19</jersey.version>
         <mockserver.version>5.13.2</mockserver.version>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1583

Minor updates to build/run under java 17

See also: https://github.com/DataBiosphere/consent/pull/1412

## Testing

- Download and install java 17 in some way. We use [eclipse-temurin](https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot) to build the app in Docker, so that's a good choice. [Brew's openjdk@17](https://formulae.brew.sh/formula/openjdk) is also a decent choice.
- Update your JAVA_HOME to point to your installation.
- Update your IDE project preferences to use java 17 and its language features. 
![Screen Shot 2022-08-09 at 5 38 45 PM](https://user-images.githubusercontent.com/116679/183766418-ff1da164-8e5e-4a76-8eae-5d9d269eca83.png)
- Update your local compose file to use `us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian` as the base image.
- Test away.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
