### PR TITLE
[DUOS-1583][risk=no] Another maven compiler config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
     <properties>
         <dropwizard.version>2.1.1</dropwizard.version>
         <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <jena.version>2.6.4</jena.version>
         <jersey.version>2.19</jersey.version>
         <mockserver.version>5.13.2</mockserver.version>
@@ -90,9 +92,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
-                <configuration>
-                    <release>11</release>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
+                <configuration>
+                  <release>17</release>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1583

I missed this config in the initial migration

See also: https://github.com/DataBiosphere/consent/pull/1702

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
