### PR TITLE
[DUOS-2155][risk=no] Refactor Sentry Logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,15 +313,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.dhatim</groupId>
-            <artifactId>dropwizard-sentry</artifactId>
-            <version>2.0.22</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <version>6.5.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyLogger.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyLogger.java
@@ -1,0 +1,55 @@
+package org.broadinstitute.dsde.consent.ontology;
+
+import io.sentry.Sentry;
+import io.sentry.SentryEvent;
+
+public interface OntologyLogger {
+
+  /**
+   * Logs an error message to the console and to Sentry
+   * @param message Error Message
+   */
+  default void logError(String message) {
+    Utils.getLogger(this.getClass()).error(message);
+    Sentry.captureEvent(new SentryEvent(new Exception(message)));
+  }
+
+  /**
+   * Logs an exception to the console and to Sentry
+   * @param e Exception
+   */
+  default void logException(Exception e) {
+    Utils.getLogger(this.getClass()).error(e.getMessage());
+    Sentry.captureEvent(new SentryEvent(e));
+  }
+
+  default void logException(String message, Exception e) {
+    Utils.getLogger(this.getClass()).error(message + e.getMessage());
+    Sentry.captureEvent(new SentryEvent(e));
+  }
+
+  /**
+   * Logs a warning message to the console
+   * @param message Error Message
+   */
+  default void logWarn(String message) {
+    Utils.getLogger(this.getClass()).warn(message);
+  }
+
+  /**
+   * Logs an info message to the console
+   * @param message Error Message
+   */
+  default void logInfo(String message) {
+    Utils.getLogger(this.getClass()).info(message);
+  }
+
+  /**
+   * Logs a debug message to the console
+   * @param message Error Message
+   */
+  default void logDebug(String message) {
+    Utils.getLogger(this.getClass()).debug(message);
+  }
+
+}

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/cloudstore/GCSStore.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/cloudstore/GCSStore.java
@@ -10,22 +10,18 @@ import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageScopes;
 import com.google.api.services.storage.model.Bucket;
-import org.broadinstitute.dsde.consent.ontology.Utils;
-import org.broadinstitute.dsde.consent.ontology.configurations.StoreConfiguration;
-import org.slf4j.Logger;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
+import org.broadinstitute.dsde.consent.ontology.configurations.StoreConfiguration;
 
-public class GCSStore implements CloudStore {
+public class GCSStore implements CloudStore, OntologyLogger {
     private final static HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
     private StoreConfiguration sConfig;
     private HttpRequestFactory requestFactory;
-
-    private final Logger log = Utils.getLogger(this.getClass());
 
     public GCSStore(StoreConfiguration config) throws GeneralSecurityException, IOException {
         sConfig = config;
@@ -43,7 +39,7 @@ public class GCSStore implements CloudStore {
                 fromStream(new FileInputStream(sConfig.getPassword())).
                 createScoped(Collections.singletonList(StorageScopes.DEVSTORAGE_FULL_CONTROL));
         } catch (Exception e) {
-            log.error("Error on GCS Store initialization. Service won't work: " + e);
+            logException("Error on GCS Store initialization. Service won't work", e);
             throw new RuntimeException(e);
         }
         return credential;

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/api/LuceneOntologyTermSearchAPI.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/api/LuceneOntologyTermSearchAPI.java
@@ -17,7 +17,7 @@ import java.util.stream.Stream;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.TextField;
-import org.broadinstitute.dsde.consent.ontology.Utils;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
 import org.broadinstitute.dsde.consent.ontology.datause.models.OntologyTerm;
 import org.broadinstitute.dsde.consent.ontology.service.StoreOntologyService;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -34,12 +34,9 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.UnloadableImportException;
 import org.semanticweb.owlapi.search.EntitySearcher;
-import org.slf4j.Logger;
 
 @Singleton
-public class LuceneOntologyTermSearchAPI implements OntologyTermSearchAPI {
-
-    private final Logger log = Utils.getLogger(this.getClass());
+public class LuceneOntologyTermSearchAPI implements OntologyTermSearchAPI, OntologyLogger {
 
     private static final String FIELD_ID = "id";
     private static final String FIELD_COMMENT = "comment";
@@ -150,7 +147,7 @@ public class LuceneOntologyTermSearchAPI implements OntologyTermSearchAPI {
                 // These checks are run on app initialization and do not
                 // represent a fatal failure of the application.
                 // Log errors and continue with app startup.
-                log.error("Unable to parse string to url: " + e.getMessage());
+                logException("Unable to parse string to url", e);
             }
         }
     }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/services/TextTranslationServiceImpl.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.dsde.consent.ontology.Utils;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSStore;
 import org.broadinstitute.dsde.consent.ontology.enumerations.TranslateFor;
 import org.broadinstitute.dsde.consent.ontology.model.DataUse;
@@ -26,11 +26,8 @@ import org.broadinstitute.dsde.consent.ontology.model.Recommendation;
 import org.broadinstitute.dsde.consent.ontology.model.TermItem;
 import org.broadinstitute.dsde.consent.ontology.model.TermResource;
 import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
-import org.slf4j.Logger;
 
-public class TextTranslationServiceImpl implements TextTranslationService {
-
-    private final Logger log = Utils.getLogger(this.getClass());
+public class TextTranslationServiceImpl implements TextTranslationService, OntologyLogger {
 
     private static final String YES = "Yes";
     private static final String FEMALE = "Female";
@@ -151,7 +148,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
             }.getType()
         );
       } catch (Exception e) {
-        log.error("Error processing search terms from GCS: " + e);
+        logException("Error processing search terms from GCS", e);
       }
       return List.of();
     }
@@ -184,10 +181,10 @@ public class TextTranslationServiceImpl implements TextTranslationService {
                     if (!terms.isEmpty()) {
                         labels.add(terms.get(0).label);
                     } else {
-                        log.warn("No terms returned for: " + r);
+                        logWarn("No terms returned for: " + r);
                     }
                 } catch (IOException e) {
-                    log.warn("Unable to retrieve term id: " + r);
+                    logWarn("Unable to retrieve term id: " + r);
                 }
             });
             if (!labels.isEmpty()) {
@@ -255,7 +252,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
                 String date = DATE_FORMAT.format(dataUse.getDateRestriction());
                 secondary.add(new DataUseElement("TS", String.format(DATE_POS, date)));
             } catch (IllegalArgumentException e) {
-                log.warn("Invalid date format for: " + dataUse.getDateRestriction());
+                logWarn("Invalid date format for: " + dataUse.getDateRestriction());
             }
         }
         if (Optional.ofNullable(dataUse.getAggregateResearch()).orElse("na").equalsIgnoreCase(YES)) {
@@ -334,10 +331,10 @@ public class TextTranslationServiceImpl implements TextTranslationService {
                     if (!terms.isEmpty()) {
                         labels.add(terms.get(0).label);
                     } else {
-                        log.warn("No terms returned for: " + r);
+                        logWarn("No terms returned for: " + r);
                     }
                 } catch (IOException e) {
-                    log.warn("Unable to retrieve term id: " + r);
+                    logWarn("Unable to retrieve term id: " + r);
                 }
             });
             if (!labels.isEmpty()) {
@@ -401,7 +398,7 @@ public class TextTranslationServiceImpl implements TextTranslationService {
                 String date = DATE_FORMAT.format(dataUse.getDateRestriction());
                 summary.add(String.format(DATE_POS, date));
             } catch (IllegalArgumentException e) {
-                log.warn("Invalid date format for: " + dataUse.getDateRestriction());
+                logWarn("Invalid date format for: " + dataUse.getDateRestriction());
             }
         }
         if (Optional.ofNullable(dataUse.getAggregateResearch()).orElse("na").equalsIgnoreCase(YES)) {

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/DataUseResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/DataUseResource.java
@@ -1,15 +1,6 @@
 package org.broadinstitute.dsde.consent.ontology.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.broadinstitute.dsde.consent.ontology.Utils;
-import org.broadinstitute.dsde.consent.ontology.datause.builder.ConsentRestrictionBuilder;
-import org.broadinstitute.dsde.consent.ontology.datause.builder.DARRestrictionBuilder;
-import org.broadinstitute.dsde.consent.ontology.datause.builder.UseRestrictionBuilder;
-import org.broadinstitute.dsde.consent.ontology.datause.models.UseRestriction;
-import org.broadinstitute.dsde.consent.ontology.model.DataUse;
-import org.parboiled.common.FileUtils;
-import org.slf4j.Logger;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -17,11 +8,16 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
+import org.broadinstitute.dsde.consent.ontology.datause.builder.ConsentRestrictionBuilder;
+import org.broadinstitute.dsde.consent.ontology.datause.builder.DARRestrictionBuilder;
+import org.broadinstitute.dsde.consent.ontology.datause.builder.UseRestrictionBuilder;
+import org.broadinstitute.dsde.consent.ontology.datause.models.UseRestriction;
+import org.broadinstitute.dsde.consent.ontology.model.DataUse;
+import org.parboiled.common.FileUtils;
 
 @Path("/schemas")
-public class DataUseResource {
-
-    private final Logger log = Utils.getLogger(this.getClass());
+public class DataUseResource implements OntologyLogger {
 
     @GET
     @Path("/data-use")
@@ -68,7 +64,7 @@ public class DataUseResource {
             UseRestriction restriction = builder.buildUseRestriction(schema);
             return Response.ok().entity(restriction).type(MediaType.APPLICATION_JSON).build();
         } catch (Exception e) {
-            log.error(e.getMessage());
+            logException(e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e).type(MediaType.APPLICATION_JSON).build();
         }
     }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
@@ -31,7 +31,7 @@ public class StatusResource implements OntologyLogger {
     @Produces("application/json")
     @Path("error")
     public Response error(@QueryParam("message") String message) {
-      logException(new Exception(String.format("Logged Exception: %s", message)));
+      logError(String.format("Logged Exception: %s", message));
       return Response.ok().build();
     }
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/SwaggerResource.java
@@ -12,14 +12,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.dsde.consent.ontology.Utils;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
 import org.parboiled.common.FileUtils;
-import org.slf4j.Logger;
 
 @Path("/")
-public class SwaggerResource {
+public class SwaggerResource implements OntologyLogger {
 
-    private final Logger log = Utils.getLogger(this.getClass());
     private final static String DEFAULT_LIB = "META-INF/resources/webjars/swagger-ui/latest/";
     final static String MEDIA_TYPE_CSS = new MediaType("text", "css").toString();
     final static String MEDIA_TYPE_JS = new MediaType("application", "javascript").toString();
@@ -36,12 +34,12 @@ public class SwaggerResource {
                 if (StringUtils.isNotEmpty(p.getProperty("swagger.ui.path"))) {
                     swaggerResource = p.getProperty("swagger.ui.path");
                 } else {
-                    log.warn("swagger.ui.path is not configured correctly, defaulting to: " + DEFAULT_LIB);
+                    logWarn("swagger.ui.path is not configured correctly, defaulting to: " + DEFAULT_LIB);
                     swaggerResource = DEFAULT_LIB;
                 }
             } catch (Exception e) {
-                log.warn(e.getMessage());
-                log.warn("Defaulting to: " + DEFAULT_LIB);
+                logException(e);
+                logWarn("Defaulting to: " + DEFAULT_LIB);
                 swaggerResource = DEFAULT_LIB;
             }
         }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/TranslateResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/TranslateResource.java
@@ -15,17 +15,15 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.dsde.consent.ontology.Utils;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
 import org.broadinstitute.dsde.consent.ontology.datause.services.TextTranslationService;
 import org.broadinstitute.dsde.consent.ontology.enumerations.TranslateFor;
 import org.broadinstitute.dsde.consent.ontology.model.Recommendation;
-import org.slf4j.Logger;
 
 
 @Path("/translate")
-public class TranslateResource {
+public class TranslateResource implements OntologyLogger {
 
-  private final Logger log = Utils.getLogger(this.getClass());
   private final TextTranslationService translationService;
   private final ObjectMapper mapper = new ObjectMapper();
 
@@ -41,7 +39,7 @@ public class TranslateResource {
     try {
       return Response.ok().entity(translationService.translateDataUseSummary(restriction)).build();
     } catch (Exception e) {
-      log.error("Error while translating", e);
+      logException("Error while translating", e);
       return Response.
           status(Response.Status.INTERNAL_SERVER_ERROR).
           entity("Error while translating: " + e.getMessage()).
@@ -56,7 +54,7 @@ public class TranslateResource {
       TranslateFor translateFor = TranslateFor.find(forParam);
       return buildResponse(translateFor, restriction);
     } catch (Exception e) {
-      log.error("Error while translating", e);
+      logException("Error while translating", e);
       return Response.
           status(Response.Status.INTERNAL_SERVER_ERROR).
           entity("Error while translating: " + e.getMessage()).
@@ -76,7 +74,7 @@ public class TranslateResource {
           return buildResponse(PARAGRAPH, paragraph);
         } catch (Exception e) {
           String message = "Server Error translating paragraph";
-          log.error(message, e);
+          logException(message, e);
           return Response
             .status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message)
             .build();

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/VersionResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/VersionResource.java
@@ -1,25 +1,16 @@
 package org.broadinstitute.dsde.consent.ontology.resources;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import org.apache.commons.io.IOUtils;
-import org.broadinstitute.dsde.consent.ontology.Utils;
-import org.broadinstitute.dsde.consent.ontology.model.Version;
-import org.slf4j.Logger;
-
+import java.nio.charset.Charset;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.nio.charset.Charset;
-import java.util.Objects;
-import java.util.Optional;
+import org.apache.commons.io.IOUtils;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
+import org.broadinstitute.dsde.consent.ontology.model.Version;
 
 @Path("/version")
-public class VersionResource {
-
-    private final Logger log = Utils.getLogger(this.getClass());
+public class VersionResource implements OntologyLogger {
 
     @GET
     @Produces("application/json")
@@ -32,7 +23,7 @@ public class VersionResource {
         try {
             return IOUtils.resourceToString("/git.properties", Charset.defaultCharset());
         } catch (Exception e) {
-            log.error(e.getMessage());
+            logException(e);
         }
         return null;
     }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/OntModelFactory.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/OntModelFactory.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.function.Predicate;
-import org.broadinstitute.dsde.consent.ontology.Utils;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
 import org.broadinstitute.dsde.consent.ontology.datause.models.UseRestriction;
 import org.broadinstitute.dsde.consent.ontology.model.MatchMessage;
 import org.mindswap.pellet.PelletOptions;
@@ -23,13 +23,10 @@ import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyAlreadyExistsException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.search.EntitySearcher;
-import org.slf4j.Logger;
 
-public enum OntModelFactory {
+public enum OntModelFactory implements OntologyLogger {
 
   INSTANCE;
-
-  private final Logger log = Utils.getLogger(this.getClass());
 
   @SuppressWarnings("unused")
   public final Boolean matchPurpose(MatchMessage message) throws Exception {
@@ -48,7 +45,7 @@ public enum OntModelFactory {
     try {
       ((PelletInfGraph) model.getGraph()).classify();
     } catch (NullPointerException e) {
-      log.warn("Non-fatal exception classifying: " + e.getMessage());
+      logWarn("Non-fatal exception classifying: " + e.getMessage());
     }
     OntClass reclassifiedConsentClass = model.getOntClass(consentId);
     return purpose.hasSuperClass(reclassifiedConsentClass);
@@ -67,13 +64,13 @@ public enum OntModelFactory {
     OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
     OntModel model = ModelFactory.createOntologyModel(PelletReasonerFactory.THE_SPEC);
     for (URL resource : resources) {
-      log.debug("Loading resource: " + resource);
+      logDebug("Loading resource: " + resource);
       try (InputStream is = resource.openStream()) {
         OWLOntology ontology;
         try {
           ontology = manager.loadOntologyFromOntologyDocument(is);
         } catch (OWLOntologyAlreadyExistsException e) {
-          log.warn("Duplicate ontology exists, skipping this one: " + e.getMessage());
+          logWarn("Duplicate ontology exists, skipping this one: " + e.getMessage());
           break;
         }
         HashMap<String, OWLAnnotationProperty> annotationProperties = new HashMap<>();
@@ -90,7 +87,7 @@ public enum OntModelFactory {
               boolean anyDeprecated = owlClass.annotationPropertiesInSignature()
                   .anyMatch(hasDeprecated);
               if (anyDeprecated) {
-                log.info("Class has deprecated terms: " + owlClass);
+                logInfo("Class has deprecated terms: " + owlClass);
               }
               // Do not load deprecated classes.
               if (!anyDeprecated) {

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/StoreOntologyService.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/StoreOntologyService.java
@@ -3,10 +3,6 @@ package org.broadinstitute.dsde.consent.ontology.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseException;
-import org.broadinstitute.dsde.consent.ontology.Utils;
-import org.broadinstitute.dsde.consent.ontology.cloudstore.CloudStore;
-import org.slf4j.Logger;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -15,14 +11,15 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
+import org.broadinstitute.dsde.consent.ontology.cloudstore.CloudStore;
 
 /**
  * Created by SantiagoSaucedo on 3/11/2016.
  */
 @SuppressWarnings("FieldCanBeLocal")
-public class StoreOntologyService {
+public class StoreOntologyService implements OntologyLogger {
 
-    private final Logger log = Utils.getLogger(this.getClass());
     private final ObjectMapper MAPPER = new ObjectMapper();
     private final CloudStore store;
     private final String bucketSubdirectory;
@@ -42,9 +39,9 @@ public class StoreOntologyService {
             return response.parseAsString();
         } catch (Exception e) {
             if (e instanceof HttpResponseException && ((HttpResponseException) e).getStatusCode() == 404) {
-                log.error("Storage service did not find Ontology configuration file: " + suffix);
+                logError("Storage service did not find Ontology configuration file: " + suffix);
             } else {
-                log.error("Problem with storage service. " + e.getMessage());
+                logException("Problem with storage service.", e);
             }
         }
         return "";
@@ -57,7 +54,7 @@ public class StoreOntologyService {
                 try {
                     return new URL(str);
                 } catch (MalformedURLException e) {
-                    log.error("Unable to convert key name to url: " + str);
+                    logError("Unable to convert key name to url: " + str);
                 }
                 return null;
             }).

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/UseRestrictionValidator.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/UseRestrictionValidator.java
@@ -2,24 +2,21 @@ package org.broadinstitute.dsde.consent.ontology.service;
 
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.inject.Inject;
-import org.broadinstitute.dsde.consent.ontology.Utils;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
 import org.broadinstitute.dsde.consent.ontology.datause.api.OntologyTermSearchAPI;
 import org.broadinstitute.dsde.consent.ontology.datause.models.OntologyTerm;
 import org.broadinstitute.dsde.consent.ontology.datause.models.UseRestriction;
 import org.broadinstitute.dsde.consent.ontology.datause.models.visitor.NamedVisitor;
 import org.broadinstitute.dsde.consent.ontology.enumerations.UseRestrictionKeys;
 import org.broadinstitute.dsde.consent.ontology.model.ValidationResponse;
-import org.slf4j.Logger;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+public class UseRestrictionValidator implements UseRestrictionValidationService, OntologyLogger {
 
-public class UseRestrictionValidator implements UseRestrictionValidationService {
-
-    private final Logger log = Utils.getLogger(this.getClass());
     private OntologyTermSearchAPI ontologyTermSearchAPI;
 
     @Inject
@@ -29,7 +26,7 @@ public class UseRestrictionValidator implements UseRestrictionValidationService 
 
     @Override
     public ValidationResponse validateUseRestriction(String useRestriction) throws Exception {
-        log.debug("Received use restriction: " + useRestriction);
+        logDebug("Received use restriction: " + useRestriction);
         ValidationResponse isValid = new ValidationResponse(true, useRestriction);
         try {
             UseRestriction restriction = UseRestriction.parse(useRestriction);

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -286,8 +286,8 @@ paths:
           description: Some number of subsystems are not OK.
   /status/error:
     get:
-      summary: Generate a logged 500 error
-      description: Generate a logged 500 error
+      summary: Generate a logged error
+      description: Generate a logged error
       parameters:
         - in: query
           name: message

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -284,6 +284,23 @@ paths:
           description: All systems are OK
         500:
           description: Some number of subsystems are not OK.
+  /status/error:
+    get:
+      summary: Generate a logged 500 error
+      description: Generate a logged 500 error
+      parameters:
+        - in: query
+          name: message
+          description: Message to log as an error
+          required: false
+          type: string
+      tags:
+        - Status
+      responses:
+        200:
+          description: Error successfully logged
+        500:
+          description: Other error
 
   /liveness:
     get:


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2155

Current sentry bootstrapping does not work in production environments. This PR manually creates Sentry events for reporting. No configuration changes are necessary in terra-helmfile. Note that the environment is not set, which is a non-issue since each DSN is directed to a specific environment section in the Sentry UI.

### Testing
* Grab a new [sentry dsn from vault](https://github.com/broadinstitute/terra-helmfile/blob/master/values/app/consent/live/alpha.yaml#L46) and use that as a system environment variable in your compose file.
* Spin up a local ontology and use the new /status/error endpoint 
* Visit [our sentry instance](https://sentry.io/organizations/broad-institute) to see the generated error

### Example
<img width="1594" alt="Screen Shot 2022-10-13 at 12 33 38 PM" src="https://user-images.githubusercontent.com/116679/195654413-6763193b-a64f-4adf-9c73-d17736d52744.png">

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
