### PR TITLE
[DUOS-1740][risk=no] Quiet CI Output

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -32,8 +32,8 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v --batch-mode
+          mvn -v
           mvn clean jacoco:prepare-agent test jacoco:report --batch-mode
           mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN --batch-mode

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,7 +27,7 @@ jobs:
         if: github.actor == 'dependabot[bot]'
         env:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-        run: mvn clean test
+        run: mvn clean test --batch-mode
       - name: Test Report
         if: github.actor != 'dependabot[bot]'
         env:
@@ -35,5 +35,5 @@ jobs:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report
-          mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN
+          mvn clean jacoco:prepare-agent test jacoco:report --batch-mode
+          mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN --batch-mode

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Test Only
         if: github.actor == 'dependabot[bot]'
         env:
-          MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: mvn clean test --batch-mode
       - name: Test Report
         if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,6 +34,6 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v
+          mvn -v --batch-mode
           mvn clean jacoco:prepare-agent test jacoco:report --batch-mode
           mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN --batch-mode

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -21,5 +21,5 @@ jobs:
         env:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v
+          mvn -v --batch-mode
           mvn clean package --batch-mode

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -19,7 +19,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Package
         env:
-          MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
-          mvn -v --batch-mode
+          mvn -v
           mvn clean package --batch-mode

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -22,4 +22,4 @@ jobs:
           MAVEN_OPTS: -Dmaven.test.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean package
+          mvn clean package --batch-mode

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -15,7 +15,7 @@ jobs:
           java-version: 17
       - name: Run Report
         run: |
-          mvn -v
+          mvn -v --batch-mode
           mvn dependency-check:check --batch-mode
       - name: Archive Report
         uses: actions/upload-artifact@v3

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -14,8 +14,10 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - name: Run Report
+        env:
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
         run: |
-          mvn -v --batch-mode
+          mvn -v
           mvn dependency-check:check --batch-mode
       - name: Archive Report
         uses: actions/upload-artifact@v3

--- a/.github/workflows/owasp.yaml
+++ b/.github/workflows/owasp.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Run Report
         run: |
           mvn -v
-          mvn dependency-check:check --no-transfer-progress
+          mvn dependency-check:check --batch-mode
       - name: Archive Report
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

Minor update to mvn commands to quiet the output. See https://github.com/DataBiosphere/consent/pull/1830 for the Consent version.

Compare, for example, a previous run with a current run:
Old: https://github.com/DataBiosphere/consent-ontology/actions/runs/3527096676/jobs/5915777248
New: https://github.com/DataBiosphere/consent-ontology/actions/runs/3567235395/jobs/5994674574

You'll see a lot less of 
```
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/shared/file-management/3.1.0/file-management-3.1.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/3.6.0/maven-archiver-3.6.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/3.4.0/plexus-io-3.4.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/4.4.0/plexus-archiver-4.4.0.jar
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.4.2/plexus-utils-3.4.2.jar
Progress (1): 2.7/36 kB
Progress (1): 5.5/36 kB
Progress (1): 8.2/36 kB
Progress (1): 11/36 kB 
Progress (1): 14/36 kB
```
which should make logs easier to navigate.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
