### PR TITLE
[DUOS-2224] Fix Ontology build code to update Sherlock for automatic deployments on PR merge

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ env:
 jobs:
   tag-build-push:
     runs-on: ubuntu-latest
+    outputs:
+      sherlock-version: ${{ steps.short-sha.outputs.sha }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -55,14 +57,6 @@ jobs:
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}
-    - name: Dispatch to terra-helmfile
-      if: github.event_name == 'push'
-      uses: broadinstitute/repository-dispatch@master
-      with:
-        token: ${{ secrets.BROADBOT_TOKEN }}
-        repository: broadinstitute/terra-helmfile
-        event-type: update-service
-        client-payload: '{"service": "ontology", "version": "${{ steps.short-sha.outputs.sha }}", "dev_only": false}'
     - name: Notify Slack
       # only notify for develop branch build
       if: github.event_name == 'push'
@@ -74,3 +68,25 @@ jobs:
         status: ${{ job.status }}
         channel: "#duos-notifications"
         fields: repo,commit,author,action,eventName,ref,workflow,job,took
+  report-to-sherlock:
+    if: github.event_name == 'push'
+      uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+      needs: [ tag-build-push ]
+      with:
+        new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
+        chart-name: 'duos'
+      permissions:
+        contents: 'read'
+        id-token: 'write'
+  set-version-in-dev:
+    if: github.event_name == 'push'
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [ tag-build-push, report-to-sherlock ]
+    with:
+      new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
+      chart-name: 'duos'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
       needs: [ tag-build-push ]
       with:
         new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
-        chart-name: 'duos'
+        chart-name: 'ontology'
       permissions:
         contents: 'read'
         id-token: 'write'
@@ -84,7 +84,7 @@ jobs:
     needs: [ tag-build-push, report-to-sherlock ]
     with:
       new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
-      chart-name: 'duos'
+      chart-name: 'ontology'
       environment-name: 'dev'
     secrets:
       sync-git-token: ${{ secrets.BROADBOT_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,14 +70,14 @@ jobs:
         fields: repo,commit,author,action,eventName,ref,workflow,job,took
   report-to-sherlock:
     if: github.event_name == 'push'
-      uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-      needs: [ tag-build-push ]
-      with:
-        new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
-        chart-name: 'ontology'
-      permissions:
-        contents: 'read'
-        id-token: 'write'
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: [ tag-build-push ]
+    with:
+      new-version: ${{ needs.tag-build-push.outputs.sherlock-version }}
+      chart-name: 'ontology'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
   set-version-in-dev:
     if: github.event_name == 'push'
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main


### PR DESCRIPTION
[DUOS-2224](https://broadworkbench.atlassian.net/browse/DUOS-2224)

-Removed "Dispatch to terra-helmfile" step
-Added "report-to-sherlock" and "set-version-in-dev" jobs to the consent build.yaml.

Changes modeled off of similar changes to UI:
-https://github.com/DataBiosphere/duos-ui/pull/1949/files
-https://github.com/DataBiosphere/duos-ui/commit/ce107ac0c5e190291b9c29d4a45e2784d08e43d7

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
