### PR TITLE
[DUOS-1740][risk=no] Add Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
       - dependency
     commit-message:
       prefix: "[DUOS-1740-dependabot]"
+    groups:
+      maven-dependencies:
+        patterns: "*"
   - package-ecosystem: docker
     directory: "/"
     schedule:
@@ -24,3 +27,6 @@ updates:
       - dependency
     commit-message:
       prefix: "[DUOS-1740-dependabot]"
+    groups:
+      docker-dependencies:
+        patterns: "*"


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

### Summary
Add group to enable grouped dependabot PRs. See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/ for more info.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
