### PR TITLE
[DUOS-1740][risk=no] Switch dependabot group pattern to array

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
       prefix: "[DUOS-1740-dependabot]"
     groups:
       maven-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: "/"
     schedule:
@@ -29,4 +30,5 @@ updates:
       prefix: "[DUOS-1740-dependabot]"
     groups:
       docker-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1740

### Summary

Dependabot group pattern is required to be an array

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
