### PR TITLE
[DUOS-2617][risk=no] Update v3 for DAR abstain cases

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCasesV3.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCasesV3.java
@@ -255,6 +255,23 @@ public class DataUseMatchCasesV3 {
   static MatchResult abstainDecision(
       DataUseV3 purpose, DataUseV3 dataset, Map<String, List<String>> purposeDiseaseIdMap,
       MatchResultType diseaseMatch) {
+
+    // Immediate Abstain Cases:
+    if (
+        getNullableOrFalse(purpose.getControls()) ||
+            getNullableOrFalse(purpose.getPopulation()) ||
+            Objects.nonNull(purpose.getGender()) ||
+            getNullableOrFalse(purpose.getPediatric()) ||
+            getNullableOrFalse(purpose.getVulnerablePopulations()) ||
+            getNullableOrFalse(purpose.getIllegalBehavior()) ||
+            getNullableOrFalse(purpose.getSexualDiseases()) ||
+            getNullableOrFalse(purpose.getPsychologicalTraits()) ||
+            getNullableOrFalse(purpose.getNotHealth()) ||
+            getNullableOrFalse(purpose.getStigmatizeDiseases())
+    ) {
+      return MatchResult.from(MatchResultType.ABSTAIN, Collections.singletonList(ABSTAIN));
+    }
+
     // Valid RPs
     boolean purposeDSX = getNullableOrFalse(!purpose.getDiseaseRestrictions().isEmpty());
     boolean purposeHMB = getNullableOrFalse(purpose.getHmbResearch());

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseBuilderV3.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseBuilderV3.java
@@ -72,4 +72,75 @@ public class DataUseBuilderV3 {
     du.setCollaboratorRequired(collaboratorRequired);
     return this;
   }
+
+  public DataUseBuilderV3 setGeographicalRestrictions(String geographicalRestrictions) {
+    du.setGeographicalRestrictions(geographicalRestrictions);
+    return this;
+  }
+
+  public DataUseBuilderV3 setGeneticStudiesOnly(boolean geneticStudiesOnly) {
+    du.setGeneticStudiesOnly(geneticStudiesOnly);
+    return this;
+  }
+
+  public DataUseBuilderV3 setPublicationResults(boolean publicationResults) {
+    du.setPublicationResults(publicationResults);
+    return this;
+  }
+
+  public DataUseBuilderV3 setPublicationMoratorium(String publicationMoratorium) {
+    du.setPublicationMoratorium(publicationMoratorium);
+    return this;
+  }
+
+  public DataUseBuilderV3 setControls(boolean controls) {
+    du.setControls(controls);
+    return this;
+  }
+
+  public DataUseBuilderV3 setGender(String gender) {
+    du.setGender(gender);
+    return this;
+  }
+
+  public DataUseBuilderV3 setPediatric(boolean pediatric) {
+    du.setPediatric(pediatric);
+    return this;
+  }
+
+  public DataUseBuilderV3 setPopulation(boolean population) {
+    du.setPopulation(population);
+    return this;
+  }
+
+  public DataUseBuilderV3 setIllegalBehavior(boolean illegalBehavior) {
+    du.setIllegalBehavior(illegalBehavior);
+    return this;
+  }
+
+  public DataUseBuilderV3 setSexualDiseases(boolean sexualDiseases) {
+    du.setSexualDiseases(sexualDiseases);
+    return this;
+  }
+
+  public DataUseBuilderV3 setStigmatizeDiseases(boolean stigmatizeDiseases) {
+    du.setStigmatizeDiseases(stigmatizeDiseases);
+    return this;
+  }
+
+  public DataUseBuilderV3 setVulnerablePopulations(boolean vulnerablePopulations) {
+    du.setVulnerablePopulations(vulnerablePopulations);
+    return this;
+  }
+
+  public DataUseBuilderV3 setPsychologicalTraits(boolean psychologicalTraits) {
+    du.setPsychologicalTraits(psychologicalTraits);
+    return this;
+  }
+
+  public DataUseBuilderV3 setNotHealth(boolean notHealth) {
+    du.setNotHealth(notHealth);
+    return this;
+  }
+
 }

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseV3.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseV3.java
@@ -7,18 +7,29 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+
 /**
  * Data Use Schema V3
+ * <p>
+ * Dynamically generated java class from jsonschema2pojo
+ * <p>
+ * See: <a
+ * href="https://github.com/joelittlejohn/jsonschema2pojo">https://github.com/joelittlejohn/jsonschema2pojo</a>
+ * <code>jsonschema2pojo --source src/main/resources/data-use-v3.json --target java-gen</code>
+ * <p>
+ * Also see <a
+ * href="https://jsonschemalint.com/#!/version/draft-07/markup/json">https://jsonschemalint.com/#!/version/draft-07/markup/json</a>
+ * for validating json.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "generalUse",
-    "hmbResearch",
     "diseaseRestrictions",
+    "hmbResearch",
     "populationOriginsAncestry",
+    "methodsResearch",
     "commercialUse",
     "nonProfitUse",
-    "methodsResearch",
     "other",
     "secondaryOther",
     "ethicsApprovalRequired",
@@ -26,24 +37,34 @@ import java.util.Objects;
     "geographicalRestrictions",
     "geneticStudiesOnly",
     "publicationResults",
-    "publicationMoratorium"
+    "publicationMoratorium",
+    "controls",
+    "gender",
+    "pediatric",
+    "population",
+    "illegalBehavior",
+    "sexualDiseases",
+    "stigmatizeDiseases",
+    "vulnerablePopulations",
+    "psychologicalTraits",
+    "notHealth"
 })
 public class DataUseV3 {
 
   @JsonProperty("generalUse")
   private Boolean generalUse;
+  @JsonProperty("diseaseRestrictions")
+  private List<String> diseaseRestrictions = new ArrayList<>();
   @JsonProperty("hmbResearch")
   private Boolean hmbResearch;
-  @JsonProperty("diseaseRestrictions")
-  private List<String> diseaseRestrictions = new ArrayList<String>();
   @JsonProperty("populationOriginsAncestry")
   private Boolean populationOriginsAncestry;
+  @JsonProperty("methodsResearch")
+  private Boolean methodsResearch;
   @JsonProperty("commercialUse")
   private Boolean commercialUse;
   @JsonProperty("nonProfitUse")
   private Boolean nonProfitUse;
-  @JsonProperty("methodsResearch")
-  private Boolean methodsResearch;
   @JsonProperty("other")
   private String other;
   @JsonProperty("secondaryOther")
@@ -60,6 +81,26 @@ public class DataUseV3 {
   private Boolean publicationResults;
   @JsonProperty("publicationMoratorium")
   private String publicationMoratorium;
+  @JsonProperty("controls")
+  private Boolean controls;
+  @JsonProperty("gender")
+  private String gender;
+  @JsonProperty("pediatric")
+  private Boolean pediatric;
+  @JsonProperty("population")
+  private Boolean population;
+  @JsonProperty("illegalBehavior")
+  private Boolean illegalBehavior;
+  @JsonProperty("sexualDiseases")
+  private Boolean sexualDiseases;
+  @JsonProperty("stigmatizeDiseases")
+  private Boolean stigmatizeDiseases;
+  @JsonProperty("vulnerablePopulations")
+  private Boolean vulnerablePopulations;
+  @JsonProperty("psychologicalTraits")
+  private Boolean psychologicalTraits;
+  @JsonProperty("notHealth")
+  private Boolean notHealth;
 
   @JsonProperty("generalUse")
   public Boolean getGeneralUse() {
@@ -69,16 +110,6 @@ public class DataUseV3 {
   @JsonProperty("generalUse")
   public void setGeneralUse(Boolean generalUse) {
     this.generalUse = generalUse;
-  }
-
-  @JsonProperty("hmbResearch")
-  public Boolean getHmbResearch() {
-    return hmbResearch;
-  }
-
-  @JsonProperty("hmbResearch")
-  public void setHmbResearch(Boolean hmbResearch) {
-    this.hmbResearch = hmbResearch;
   }
 
   @JsonProperty("diseaseRestrictions")
@@ -91,6 +122,16 @@ public class DataUseV3 {
     this.diseaseRestrictions = diseaseRestrictions;
   }
 
+  @JsonProperty("hmbResearch")
+  public Boolean getHmbResearch() {
+    return hmbResearch;
+  }
+
+  @JsonProperty("hmbResearch")
+  public void setHmbResearch(Boolean hmbResearch) {
+    this.hmbResearch = hmbResearch;
+  }
+
   @JsonProperty("populationOriginsAncestry")
   public Boolean getPopulationOriginsAncestry() {
     return populationOriginsAncestry;
@@ -99,6 +140,16 @@ public class DataUseV3 {
   @JsonProperty("populationOriginsAncestry")
   public void setPopulationOriginsAncestry(Boolean populationOriginsAncestry) {
     this.populationOriginsAncestry = populationOriginsAncestry;
+  }
+
+  @JsonProperty("methodsResearch")
+  public Boolean getMethodsResearch() {
+    return methodsResearch;
+  }
+
+  @JsonProperty("methodsResearch")
+  public void setMethodsResearch(Boolean methodsResearch) {
+    this.methodsResearch = methodsResearch;
   }
 
   @JsonProperty("commercialUse")
@@ -119,16 +170,6 @@ public class DataUseV3 {
   @JsonProperty("nonProfitUse")
   public void setNonProfitUse(Boolean nonProfitUse) {
     this.nonProfitUse = nonProfitUse;
-  }
-
-  @JsonProperty("methodsResearch")
-  public Boolean getMethodsResearch() {
-    return methodsResearch;
-  }
-
-  @JsonProperty("methodsResearch")
-  public void setMethodsResearch(Boolean methodsResearch) {
-    this.methodsResearch = methodsResearch;
   }
 
   @JsonProperty("other")
@@ -211,6 +252,106 @@ public class DataUseV3 {
     this.publicationMoratorium = publicationMoratorium;
   }
 
+  @JsonProperty("controls")
+  public Boolean getControls() {
+    return controls;
+  }
+
+  @JsonProperty("controls")
+  public void setControls(Boolean controls) {
+    this.controls = controls;
+  }
+
+  @JsonProperty("gender")
+  public String getGender() {
+    return gender;
+  }
+
+  @JsonProperty("gender")
+  public void setGender(String gender) {
+    this.gender = gender;
+  }
+
+  @JsonProperty("pediatric")
+  public Boolean getPediatric() {
+    return pediatric;
+  }
+
+  @JsonProperty("pediatric")
+  public void setPediatric(Boolean pediatric) {
+    this.pediatric = pediatric;
+  }
+
+  @JsonProperty("population")
+  public Boolean getPopulation() {
+    return population;
+  }
+
+  @JsonProperty("population")
+  public void setPopulation(Boolean population) {
+    this.population = population;
+  }
+
+  @JsonProperty("illegalBehavior")
+  public Boolean getIllegalBehavior() {
+    return illegalBehavior;
+  }
+
+  @JsonProperty("illegalBehavior")
+  public void setIllegalBehavior(Boolean illegalBehavior) {
+    this.illegalBehavior = illegalBehavior;
+  }
+
+  @JsonProperty("sexualDiseases")
+  public Boolean getSexualDiseases() {
+    return sexualDiseases;
+  }
+
+  @JsonProperty("sexualDiseases")
+  public void setSexualDiseases(Boolean sexualDiseases) {
+    this.sexualDiseases = sexualDiseases;
+  }
+
+  @JsonProperty("stigmatizeDiseases")
+  public Boolean getStigmatizeDiseases() {
+    return stigmatizeDiseases;
+  }
+
+  @JsonProperty("stigmatizeDiseases")
+  public void setStigmatizeDiseases(Boolean stigmatizeDiseases) {
+    this.stigmatizeDiseases = stigmatizeDiseases;
+  }
+
+  @JsonProperty("vulnerablePopulations")
+  public Boolean getVulnerablePopulations() {
+    return vulnerablePopulations;
+  }
+
+  @JsonProperty("vulnerablePopulations")
+  public void setVulnerablePopulations(Boolean vulnerablePopulations) {
+    this.vulnerablePopulations = vulnerablePopulations;
+  }
+
+  @JsonProperty("psychologicalTraits")
+  public Boolean getPsychologicalTraits() {
+    return psychologicalTraits;
+  }
+
+  @JsonProperty("psychologicalTraits")
+  public void setPsychologicalTraits(Boolean psychologicalTraits) {
+    this.psychologicalTraits = psychologicalTraits;
+  }
+
+  @JsonProperty("notHealth")
+  public Boolean getNotHealth() {
+    return notHealth;
+  }
+
+  @JsonProperty("notHealth")
+  public void setNotHealth(Boolean notHealth) {
+    this.notHealth = notHealth;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -218,66 +359,104 @@ public class DataUseV3 {
         .append(Integer.toHexString(System.identityHashCode(this))).append('[');
     sb.append("generalUse");
     sb.append('=');
-    sb.append((Objects.isNull(this.generalUse) ? "<null>" : this.generalUse));
-    sb.append(',');
-    sb.append("hmbResearch");
-    sb.append('=');
-    sb.append((Objects.isNull(this.hmbResearch) ? "<null>" : this.hmbResearch));
+    sb.append(((this.generalUse == null) ? "<null>" : this.generalUse));
     sb.append(',');
     sb.append("diseaseRestrictions");
     sb.append('=');
-    sb.append((Objects.isNull(this.diseaseRestrictions) ? "<null>" : this.diseaseRestrictions));
+    sb.append(((this.diseaseRestrictions == null) ? "<null>" : this.diseaseRestrictions));
+    sb.append(',');
+    sb.append("hmbResearch");
+    sb.append('=');
+    sb.append(((this.hmbResearch == null) ? "<null>" : this.hmbResearch));
     sb.append(',');
     sb.append("populationOriginsAncestry");
     sb.append('=');
-    sb.append((Objects.isNull(this.populationOriginsAncestry) ? "<null>"
-        : this.populationOriginsAncestry));
-    sb.append(',');
-    sb.append("commercialUse");
-    sb.append('=');
-    sb.append((Objects.isNull(this.commercialUse) ? "<null>" : this.commercialUse));
-    sb.append(',');
-    sb.append("nonProfitUse");
-    sb.append('=');
-    sb.append((Objects.isNull(this.nonProfitUse) ? "<null>" : this.nonProfitUse));
+    sb.append(
+        ((this.populationOriginsAncestry == null) ? "<null>" : this.populationOriginsAncestry));
     sb.append(',');
     sb.append("methodsResearch");
     sb.append('=');
-    sb.append((Objects.isNull(this.methodsResearch) ? "<null>" : this.methodsResearch));
+    sb.append(((this.methodsResearch == null) ? "<null>" : this.methodsResearch));
+    sb.append(',');
+    sb.append("commercialUse");
+    sb.append('=');
+    sb.append(((this.commercialUse == null) ? "<null>" : this.commercialUse));
+    sb.append(',');
+    sb.append("nonProfitUse");
+    sb.append('=');
+    sb.append(((this.nonProfitUse == null) ? "<null>" : this.nonProfitUse));
     sb.append(',');
     sb.append("other");
     sb.append('=');
-    sb.append((Objects.isNull(this.other) ? "<null>" : this.other));
+    sb.append(((this.other == null) ? "<null>" : this.other));
     sb.append(',');
     sb.append("secondaryOther");
     sb.append('=');
-    sb.append((Objects.isNull(this.secondaryOther) ? "<null>" : this.secondaryOther));
+    sb.append(((this.secondaryOther == null) ? "<null>" : this.secondaryOther));
     sb.append(',');
     sb.append("ethicsApprovalRequired");
     sb.append('=');
-    sb.append(
-        (Objects.isNull(this.ethicsApprovalRequired) ? "<null>" : this.ethicsApprovalRequired));
+    sb.append(((this.ethicsApprovalRequired == null) ? "<null>" : this.ethicsApprovalRequired));
     sb.append(',');
     sb.append("collaboratorRequired");
     sb.append('=');
-    sb.append((Objects.isNull(this.collaboratorRequired) ? "<null>" : this.collaboratorRequired));
+    sb.append(((this.collaboratorRequired == null) ? "<null>" : this.collaboratorRequired));
     sb.append(',');
     sb.append("geographicalRestrictions");
     sb.append('=');
-    sb.append(
-        (Objects.isNull(this.geographicalRestrictions) ? "<null>" : this.geographicalRestrictions));
+    sb.append(((this.geographicalRestrictions == null) ? "<null>" : this.geographicalRestrictions));
     sb.append(',');
     sb.append("geneticStudiesOnly");
     sb.append('=');
-    sb.append((Objects.isNull(this.geneticStudiesOnly) ? "<null>" : this.geneticStudiesOnly));
+    sb.append(((this.geneticStudiesOnly == null) ? "<null>" : this.geneticStudiesOnly));
     sb.append(',');
     sb.append("publicationResults");
     sb.append('=');
-    sb.append((Objects.isNull(this.publicationResults) ? "<null>" : this.publicationResults));
+    sb.append(((this.publicationResults == null) ? "<null>" : this.publicationResults));
     sb.append(',');
     sb.append("publicationMoratorium");
     sb.append('=');
-    sb.append((Objects.isNull(this.publicationMoratorium) ? "<null>" : this.publicationMoratorium));
+    sb.append(((this.publicationMoratorium == null) ? "<null>" : this.publicationMoratorium));
+    sb.append(',');
+    sb.append("controls");
+    sb.append('=');
+    sb.append(((this.controls == null) ? "<null>" : this.controls));
+    sb.append(',');
+    sb.append("gender");
+    sb.append('=');
+    sb.append(((this.gender == null) ? "<null>" : this.gender));
+    sb.append(',');
+    sb.append("pediatric");
+    sb.append('=');
+    sb.append(((this.pediatric == null) ? "<null>" : this.pediatric));
+    sb.append(',');
+    sb.append("population");
+    sb.append('=');
+    sb.append(((this.population == null) ? "<null>" : this.population));
+    sb.append(',');
+    sb.append("illegalBehavior");
+    sb.append('=');
+    sb.append(((this.illegalBehavior == null) ? "<null>" : this.illegalBehavior));
+    sb.append(',');
+    sb.append("sexualDiseases");
+    sb.append('=');
+    sb.append(((this.sexualDiseases == null) ? "<null>" : this.sexualDiseases));
+    sb.append(',');
+    sb.append("stigmatizeDiseases");
+    sb.append('=');
+    sb.append(((this.stigmatizeDiseases == null) ? "<null>" : this.stigmatizeDiseases));
+    sb.append(',');
+    sb.append("vulnerablePopulations");
+    sb.append('=');
+    sb.append(((this.vulnerablePopulations == null) ? "<null>" : this.vulnerablePopulations));
+    sb.append(',');
+    sb.append("psychologicalTraits");
+    sb.append('=');
+    sb.append(((this.psychologicalTraits == null) ? "<null>" : this.psychologicalTraits));
+    sb.append(',');
+    sb.append("notHealth");
+    sb.append('=');
+    sb.append(((this.notHealth == null) ? "<null>" : this.notHealth));
     sb.append(',');
     if (sb.charAt((sb.length() - 1)) == ',') {
       sb.setCharAt((sb.length() - 1), ']');
@@ -290,33 +469,44 @@ public class DataUseV3 {
   @Override
   public int hashCode() {
     int result = 1;
-    result = ((result * 31) + (Objects.isNull(this.commercialUse) ? 0
-        : this.commercialUse.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.nonProfitUse) ? 0
-        : this.nonProfitUse.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.other) ? 0 : this.other.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.geneticStudiesOnly) ? 0
+    result = ((result * 31) + ((this.commercialUse == null) ? 0 : this.commercialUse.hashCode()));
+    result = ((result * 31) + ((this.other == null) ? 0 : this.other.hashCode()));
+    result = ((result * 31) + ((this.nonProfitUse == null) ? 0 : this.nonProfitUse.hashCode()));
+    result = ((result * 31) + ((this.controls == null) ? 0 : this.controls.hashCode()));
+    result = ((result * 31) + ((this.psychologicalTraits == null) ? 0
+        : this.psychologicalTraits.hashCode()));
+    result = ((result * 31) + ((this.gender == null) ? 0 : this.gender.hashCode()));
+    result = ((result * 31) + ((this.geneticStudiesOnly == null) ? 0
         : this.geneticStudiesOnly.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.generalUse) ? 0 : this.generalUse.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.publicationResults) ? 0
+    result = ((result * 31) + ((this.generalUse == null) ? 0 : this.generalUse.hashCode()));
+    result = ((result * 31) + ((this.publicationResults == null) ? 0
         : this.publicationResults.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.diseaseRestrictions) ? 0
+    result = ((result * 31) + ((this.diseaseRestrictions == null) ? 0
         : this.diseaseRestrictions.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.methodsResearch) ? 0
+    result = ((result * 31) + ((this.pediatric == null) ? 0 : this.pediatric.hashCode()));
+    result = ((result * 31) + ((this.vulnerablePopulations == null) ? 0
+        : this.vulnerablePopulations.hashCode()));
+    result = ((result * 31) + ((this.methodsResearch == null) ? 0
         : this.methodsResearch.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.publicationMoratorium) ? 0
+    result = ((result * 31) + ((this.publicationMoratorium == null) ? 0
         : this.publicationMoratorium.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.collaboratorRequired) ? 0
+    result = ((result * 31) + ((this.sexualDiseases == null) ? 0 : this.sexualDiseases.hashCode()));
+    result = ((result * 31) + ((this.illegalBehavior == null) ? 0
+        : this.illegalBehavior.hashCode()));
+    result = ((result * 31) + ((this.collaboratorRequired == null) ? 0
         : this.collaboratorRequired.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.populationOriginsAncestry) ? 0
+    result = ((result * 31) + ((this.populationOriginsAncestry == null) ? 0
         : this.populationOriginsAncestry.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.ethicsApprovalRequired) ? 0
+    result = ((result * 31) + ((this.ethicsApprovalRequired == null) ? 0
         : this.ethicsApprovalRequired.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.secondaryOther) ? 0
-        : this.secondaryOther.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.hmbResearch) ? 0 : this.hmbResearch.hashCode()));
-    result = ((result * 31) + (Objects.isNull(this.geographicalRestrictions) ? 0
+    result = ((result * 31) + ((this.secondaryOther == null) ? 0 : this.secondaryOther.hashCode()));
+    result = ((result * 31) + ((this.hmbResearch == null) ? 0 : this.hmbResearch.hashCode()));
+    result = ((result * 31) + ((this.geographicalRestrictions == null) ? 0
         : this.geographicalRestrictions.hashCode()));
+    result = ((result * 31) + ((this.population == null) ? 0 : this.population.hashCode()));
+    result = ((result * 31) + ((this.notHealth == null) ? 0 : this.notHealth.hashCode()));
+    result = ((result * 31) + ((this.stigmatizeDiseases == null) ? 0
+        : this.stigmatizeDiseases.hashCode()));
     return result;
   }
 
@@ -325,19 +515,32 @@ public class DataUseV3 {
     if (other == this) {
       return true;
     }
-    if (!(other instanceof DataUseV3)) {
+    if (!(other instanceof DataUseV3 rhs)) {
       return false;
     }
-    DataUseV3 rhs = ((DataUseV3) other);
-    return Objects.equals(this.commercialUse,
-        rhs.commercialUse) && Objects.equals(this.nonProfitUse, rhs.nonProfitUse)
-        && Objects.equals(
-        this.other, rhs.other) && Objects.equals(this.generalUse, rhs.generalUse)
-        && Objects.equals(this.diseaseRestrictions, rhs.diseaseRestrictions) && Objects.equals(
-        this.methodsResearch, rhs.methodsResearch) && Objects.equals(
-        this.populationOriginsAncestry, rhs.populationOriginsAncestry) && Objects.equals(
-        this.secondaryOther, rhs.secondaryOther) && Objects.equals(this.hmbResearch,
-        rhs.hmbResearch);
+    return (Objects.equals(this.commercialUse, rhs.commercialUse)) &&
+        Objects.equals(this.other, rhs.other) && (Objects.equals(this.nonProfitUse,
+        rhs.nonProfitUse)) && (Objects.equals(this.controls, rhs.controls)) && (
+        Objects.equals(this.psychologicalTraits, rhs.psychologicalTraits)) && Objects.equals(
+        this.gender, rhs.gender) && (Objects.equals(this.geneticStudiesOnly,
+        rhs.geneticStudiesOnly)) && (Objects.equals(this.generalUse, rhs.generalUse))
+        && (Objects.equals(this.publicationResults,
+        rhs.publicationResults)) && (Objects.equals(this.diseaseRestrictions,
+        rhs.diseaseRestrictions)) && (Objects.equals(this.pediatric, rhs.pediatric)) && (
+        Objects.equals(this.vulnerablePopulations, rhs.vulnerablePopulations)) && (Objects.equals(
+        this.methodsResearch, rhs.methodsResearch))
+        && Objects.equals(this.publicationMoratorium, rhs.publicationMoratorium) && (
+        Objects.equals(this.sexualDiseases, rhs.sexualDiseases)) && (
+        Objects.equals(this.illegalBehavior, rhs.illegalBehavior)) && (
+        Objects.equals(this.collaboratorRequired, rhs.collaboratorRequired)) && (
+        Objects.equals(this.populationOriginsAncestry, rhs.populationOriginsAncestry)) && (
+        Objects.equals(this.ethicsApprovalRequired, rhs.ethicsApprovalRequired)) && Objects.equals(
+        this.secondaryOther, rhs.secondaryOther) && (Objects.equals(this.hmbResearch,
+        rhs.hmbResearch)) && Objects.equals(this.geographicalRestrictions,
+        rhs.geographicalRestrictions) && (Objects.equals(
+        this.population, rhs.population)) && (Objects.equals(this.notHealth, rhs.notHealth))
+        && (Objects.equals(this.stigmatizeDiseases, rhs.stigmatizeDiseases));
   }
 
 }
+

--- a/src/main/resources/data-use-v3.json
+++ b/src/main/resources/data-use-v3.json
@@ -1,64 +1,138 @@
 {
-  "$id": "https://consent-ontology.dsde-prod.broadinstitute.org/schemas/data-use",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Data Use Schema V3",
-  "version": 2,
-  "type": "object",
-  "anyOf": [
-    {"required":  ["generalUse"]},
-    {"required" : ["diseaseRestrictions"]},
-    {"required" : ["hmbResearch"]}
+  "$id" : "https://consent-ontology.dsde-prod.broadinstitute.org/schemas/data-use",
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "Data Use Schema V3",
+  "version" : 3,
+  "type" : "object",
+  "anyOf" : [
+    {
+      "required" : [
+        "generalUse"
+      ]
+    },
+    {
+      "required" : [
+        "diseaseRestrictions"
+      ]
+    },
+    {
+      "required" : [
+        "hmbResearch"
+      ]
+    }
   ],
-  "properties": {
-    "generalUse": {
-      "type": "boolean"
+  "properties" : {
+    "generalUse" : {
+      "type" : "boolean",
+      "consentDescription" : "General Research Use"
     },
-    "diseaseRestrictions": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "uniqueItems": true
-      }
+    "diseaseRestrictions" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "uniqueItems" : true
+      },
+      "purposeDescription" : "Is the primary purpose of this research to investigate a specific disease(s)?",
+      "consentDescription" : "Disease-Specific Research Use"
     },
-    "hmbResearch": {
-      "type": "boolean"
+    "hmbResearch" : {
+      "type" : "boolean",
+      "purposeDescription" : "Is the primary purpose health/medical/biomedical research in nature?",
+      "consentDescription" : "Health/Medical/Biomedical Research Use"
     },
-    "populationOriginsAncestry": {
-      "type": "boolean"
+    "populationOriginsAncestry" : {
+      "type" : "boolean",
+      "purposeDescription" : "Is the primary purpose of this research regarding population origins or ancestry?",
+      "consentDescription" : "Populations, Origins, Ancestry Use"
     },
-    "methodsResearch": {
-      "type": "boolean"
+    "methodsResearch" : {
+      "type" : "boolean",
+      "purposeDescription" : "Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?",
+      "consentDescription" : "No methods development or validation studies (NMDS)"
     },
-    "commercialUse": {
-      "type": "boolean"
+    "commercialUse" : {
+      "type" : "boolean",
+      "purposeDescription" : "Conduct research for an exclusively or partially commercial purpose.",
+      "consentDescription" : ""
     },
-    "nonProfitUse": {
-      "type": "boolean"
+    "nonProfitUse" : {
+      "type" : "boolean",
+      "consentDescription" : "Non-profit Use Only (NPU)"
     },
-    "other": {
-      "type": "string"
+    "other" : {
+      "type" : "string",
+      "purposeDescription" : "Other",
+      "consentDescription" : "Other"
     },
-    "secondaryOther": {
-      "type": "string"
+    "secondaryOther" : {
+      "type" : "string",
+      "purposeDescription" : "Other",
+      "consentDescription" : "Other"
     },
-    "ethicsApprovalRequired": {
-      "type": "boolean"
+    "ethicsApprovalRequired" : {
+      "type" : "boolean",
+      "consentDescription" : "Ethics Approval Required (IRB)"
     },
-    "collaboratorRequired": {
-      "type": "boolean"
+    "collaboratorRequired" : {
+      "type" : "boolean",
+      "consentDescription" : "Collaboration Required (COL)"
     },
-    "geographicalRestrictions": {
-      "type": "string"
+    "geographicalRestrictions" : {
+      "type" : "string",
+      "consentDescription" : "Geographic Restriction (GS-)"
     },
-    "geneticStudiesOnly": {
-      "type": "boolean"
+    "geneticStudiesOnly" : {
+      "type" : "boolean",
+      "consentDescription" : "Genetic studies only (GSO)"
     },
-    "publicationResults": {
-      "type": "boolean"
+    "publicationResults" : {
+      "type" : "boolean",
+      "consentDescription" : "Publication Required (PUB)"
     },
-    "publicationMoratorium": {
-      "type": "string",
-      "format": "date"
+    "publicationMoratorium" : {
+      "type" : "string",
+      "format" : "date",
+      "consentDescription" : "Publication Moratorium (MOR)"
+    },
+    "controls" : {
+      "type" : "boolean",
+      "purposeDescription" : "Increase controls available for a comparison group (e.g. a case-control study)."
+    },
+    "gender" : {
+      "type" : "string",
+      "purposeDescription" : "Limited to one gender"
+    },
+    "pediatric" : {
+      "type" : "boolean",
+      "purposeDescription" : "Limited to a pediatric population (under the age of 18)"
+    },
+    "population" : {
+      "type" : "boolean",
+      "purposeDescription" : "Study variation in the general population (e.g. calling variants and/or studying their distribution)."
+    },
+    "illegalBehavior" : {
+      "type" : "boolean",
+      "purposeDescription" : "Illegal behaviors (violence, domestic abuse, prostitution, sexual victimization)"
+    },
+    "sexualDiseases" : {
+      "type" : "boolean",
+      "purposeDescription" : "Sexual preferences or sexually transmitted diseases"
+    },
+    "stigmatizeDiseases" : {
+      "type" : "boolean",
+      "purposeDescription" : "Stigmatizing illnesses"
+    },
+    "vulnerablePopulations" : {
+      "type" : "boolean",
+      "purposeDescription" : "Targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [“SIGNIFICANTLY”] economically or educationally disadvantaged persons)"
+    },
+    "psychologicalTraits" : {
+      "type" : "boolean",
+      "purposeDescription" : "Psychological traits, intelligence, or attention"
+    },
+    "notHealth" : {
+      "type" : "boolean",
+      "purposeDescription" : "Correlating ethnicity, race, or gender with genotypic or phenotypic variables for purposes beyond biomedical or health-related research, or in ways not easily related to health"
     }
   }
 }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV3Test.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV3Test.java
@@ -254,6 +254,76 @@ public class DataUseMatcherV3Test {
     assertAbstain(purpose, dataset);
   }
 
+  @Test
+  public void testAbstainDecision_controls() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setControls(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_population() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setPopulation(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_gender() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setGender("M").build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_pediatric() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setPediatric(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_vulnerablePopulations() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setVulnerablePopulations(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_illegalBehavior() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setIllegalBehavior(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_sexualDiseases() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setSexualDiseases(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_psychologicalTraits() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setPsychologicalTraits(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_notHealth() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setNotHealth(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_stigmatizedDiseases() {
+    DataUseV3 purpose = new DataUseBuilderV3().setHmbResearch(true).setStigmatizeDiseases(true).build();
+    DataUseV3 dataset = new DataUseBuilderV3().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
   private void assertApprove(DataUseV3 purpose, DataUseV3 dataset) {
     MatchResult match = matchPurposeAndDataset(purpose, dataset);
     assertTrue(Approve(match.getMatchResultType()));


### PR DESCRIPTION
### Addresses
Ontology side of https://broadworkbench.atlassian.net/browse/DUOS-2617

### Summary
* See also: https://github.com/DataBiosphere/consent/pull/2106
* Adds explicit abstain cases for all of the known DAR abstain questions that are not currently covered.
* Expands the v3 schema to include descriptions of the relevant term for both the purpose and consent forms where applicable.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
