### PR TITLE
[DUOS-2633] Return 404 instead of 500 on search API

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -30,13 +31,13 @@ public class OntologySearchResource {
   public Response getOntologyById(@QueryParam("id") @DefaultValue("") String queryTerm) {
     if (queryTerm.isBlank()) {
       return Response
-          .status(Response.Status.BAD_REQUEST)
+          .status(Status.BAD_REQUEST)
           .entity(new ErrorResponse("Ontology ID term cannot be empty.",
-              Response.Status.BAD_REQUEST.getStatusCode()))
+              Status.BAD_REQUEST.getStatusCode()))
           .build();
     }
 
-    String[] queries = queryTerm.split(",");
+    String[] queries = queryTerm.toUpperCase().split(",");
     try {
       List<TermResource> results = new Streams.FailableStream<>(Arrays.stream(queries))
           .filter(Objects::nonNull)
@@ -47,9 +48,9 @@ public class OntologySearchResource {
           .collect(Collectors.toList());
       return checkOntologyRetrieval(results);
     } catch (Exception e) {
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+      return Response.status(Status.NOT_FOUND)
           .entity(new ErrorResponse("Ontology could not be successfully retrieved.",
-              Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()))
+              Status.NOT_FOUND.getStatusCode()))
           .build();
     }
 
@@ -57,9 +58,9 @@ public class OntologySearchResource {
 
   private Response checkOntologyRetrieval(List<TermResource> results) {
     if (results.isEmpty()) {
-      return Response.status(Response.Status.NOT_FOUND)
+      return Response.status(Status.NOT_FOUND)
           .entity(new ErrorResponse("Supplied IDs do not match any known ontologies.",
-              Response.Status.NOT_FOUND.getStatusCode()))
+              Status.NOT_FOUND.getStatusCode()))
           .build();
     } else {
       return Response.ok().entity(results).build();

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/OntologySearchResource.java
@@ -37,7 +37,7 @@ public class OntologySearchResource {
           .build();
     }
 
-    String[] queries = queryTerm.toUpperCase().split(",");
+    String[] queries = queryTerm.split(",");
     try {
       List<TermResource> results = new Streams.FailableStream<>(Arrays.stream(queries))
           .filter(Objects::nonNull)

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/service/ElasticSearchSupport.java
@@ -157,8 +157,9 @@ class ElasticSearchSupport {
   }
 
   private String convertQueryToUrl(String query) {
-    if (query.substring(0, 4).equals("DOID")) {
-      return "http://purl.obolibrary.org/obo/" + query;
+    if (query.substring(0, 4).toUpperCase().equals("DOID")) {
+      var doid = "DOID_" + query.substring(5);
+      return "http://purl.obolibrary.org/obo/" + doid;
     }
     return query;
   }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2633

### Summary

Return 404 instead of 500 on search API

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
