### PR TITLE
[DUOS-2931][risk=no] Implement v4 Algorithm

### DIFF
--- a/docs/Algorithms.md
+++ b/docs/Algorithms.md
@@ -12,7 +12,8 @@ matching at scale.
 
 This version of the algorithm uses a custom set of business rules to match a research purpose and consented dataset.
 In determining a positive match between research purpose and consented dataset, we make sure that the consented
-dataset matches **ALL** conditions specified in the research purpose.
+dataset matches **ALL** conditions specified in the research purpose. The primary difference between this version
+and the previous version is the update to Non-Profit Use (<strong>NPU</strong>) business logic.
 
 <table>
 	<thead>

--- a/docs/Algorithms.md
+++ b/docs/Algorithms.md
@@ -5,13 +5,134 @@ of the Matching APIs. This document describes the different approaches to matchi
 and a Consent on a dataset. Both Purpose and Consent are structured objects which allows for computational
 matching at scale.
 
+## Version 4
+
+<details>
+<summary>View</summary>
+
+This version of the algorithm uses a custom set of business rules to match a research purpose and consented dataset.
+In determining a positive match between research purpose and consented dataset, we make sure that the consented
+dataset matches **ALL** conditions specified in the research purpose.
+
+<table>
+	<thead>
+		<tr>
+			<th>If my Research Purpose has...</th>
+			<th>What datasets should I see?</th>
+			<th>Logical Rationale</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Disease focused research (i.e. <strong>DS-X</strong>)</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong>GRU</strong>=true</li>
+          <li>Any dataset tagged with <strong>HMB</strong>=true</li>
+					<li>Any dataset tagged to this disease (<strong>DS-X</strong>) exactly or a parent disease of <strong>DS-X</strong></li>
+				</ul>	
+			</td>	
+			<td>
+				<ul>
+          <li><strong>Approve</strong> if the dataset's Primary DUO terms are DS- or a subclass</li>
+          <li><strong>Deny</strong> if the dataset's Primary DUO terms are NOT the DS- or a subclass</li>
+				</ul>
+			</td>
+		</tr>
+    <tr>
+			<td>Use of data is limited to health/medical/biomedical purposes, not including population origins or ancestry (i.e. <strong>HMB</strong>)</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong>GRU</strong>=true</li>
+					<li>Any dataset tagged with <strong>HMB</strong>=true</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li><strong>Approve</strong> if the dataset's Primary DUO terms are HMB, GRU</li>
+          <li><strong>Deny</strong> if the dataset's Primary DUO terms are DS-, POA</li>
+				</ul>
+			</td>
+		</tr>
+    <tr>
+			<td>Study population origins or ancestry (i.e. <strong>POA</strong>)</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong>GRU</strong>=true</li>
+          <li>Any dataset tagged with <strong>POA</strong>=true</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+          <li><strong>Approve</strong> if the dataset's Primary DUO terms are GRU, POA</li>
+          <li><strong>Deny</strong> if the dataset's Primary DUO terms are DS-, HMB</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>Methods development (i.e. <strong>MDS</strong>)</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong>GRU</strong>=true</li>
+          <li>Any dataset tagged with <strong>DS-X</strong>=true</li>
+					<li>Any dataset tagged with <strong>POA</strong>=true</li>
+					<li>Any dataset tagged with <strong>HMB</strong>=true</li>
+				</ul>	
+			</td>	
+			<td>
+				<ul>
+          <li><strong>Approve</strong> if the dataset's Primary DUO terms are GRU, DS-, HMB, POA</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>Non-profit use (i.e. <strong>NPU</strong>)</td>
+			<td>
+				<ul>
+					<li>Any dataset tagged with <strong>NPU</strong>=true</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+          <li><strong>Deny</strong> if the dataset's <strong>NPU</strong> term is false.</li>
+				</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+### Abstain from Decision
+
+Due to the variety of sensitive research areas, ethical reasons, and areas where categorization is not possible, the DUOS system will <strong>not</strong> render a decision in the following cases.
+
+<li>Other</li>
+<li>Geographical Restrictions (i.e. <strong>GS-</strong>)</li>
+<li>Public Moratorium/Embargo (i.e. <strong>MOR</strong>)</li>
+<li>Genetic Studies Only (i.e. <strong>GSO</strong>)</li>
+<li>Publication Required (i.e. <strong>PUB</strong>)</li>
+<li>Collabration Required (i.e. <strong>COL</strong>)</li>
+<li>Ethics Approval Required (i.e. <strong>IRB</strong>)</li>
+<li>Limitation to one gender</li>
+<li>Restricted to a pediatric population (under the age of 18)</li>
+<li>Illegal behaviors (violence, domestic abuse, prostitution, sexual victimization)</li>
+<li>Alcohol or drug abuse, or abuse of other addictive products</li>
+<li>Sexual preferences or sexually transmitted diseases</li>
+<li>Any stigmatizing illnesses</li>
+<li>Vulnerable populations as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or ["SIGNIFICANTLY"] economically or educationally disadvantaged persons)</li>
+<li>Population Origins/Migration patterns</li>
+<li>Psychological traits, including intelligence, attention, emotion</li>
+<li>Ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways that are not easily related to Health</li>
+
+</details>
+
+
 ## Version 3
 
 <details>
 <summary>View</summary>
 
 This version of the algorithm uses a custom set of business rules to match a research purpose and consented dataset. 
-In determining a postive match between research purpose and consented dataset, we make sure that the consented
+In determining a positive match between research purpose and consented dataset, we make sure that the consented
 dataset matches **ALL** conditions specified in the research purpose.
 
 <table>

--- a/docs/Algorithms.md
+++ b/docs/Algorithms.md
@@ -89,12 +89,18 @@ dataset matches **ALL** conditions specified in the research purpose.
 			<td>Non-profit use (i.e. <strong>NPU</strong>)</td>
 			<td>
 				<ul>
-					<li>Any dataset tagged with <strong>NPU</strong>=true</li>
+					<li>
+              Any dataset tagged with <strong>NPU</strong>=true OR <strong>NPU</strong>=false
+              Datasets with <strong>NPU</strong>=false set effectively have no restriction on NPU usage.
+          </li>
 				</ul>
 			</td>
 			<td>
 				<ul>
-          <li><strong>Deny</strong> if the dataset's <strong>NPU</strong> term is false.</li>
+          <li>
+              <strong>Deny</strong> if the research purpose is <strong>NPU</strong>=false and
+              the dataset's DUO term is <strong>NPU</strong>=true
+          </li>
 				</ul>
 			</td>
 		</tr>

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCasesV4.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatchCasesV4.java
@@ -1,0 +1,305 @@
+package org.broadinstitute.dsde.consent.ontology.datause;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import org.broadinstitute.dsde.consent.ontology.model.DataUseV4;
+
+public class DataUseMatchCasesV4 {
+
+  // rationale for failures
+  private static final String HMB_F1 = "The GRU Research Purpose does not match the HMB data use limitations.";
+  private static final String HMB_F2 = "The HMB Research Purpose does not match the Disease-Specific data use limitations.";
+  private static final String HMB_F3 = "The HMB Research Purpose does not match the POA data use limitations.";
+  private static final String DS_F2 = "The Disease-Specific: %s Research Purpose is not a valid subclass of the Disease-Specific data use limitations.";
+  private static final String MDS_F1 = "The Methods development Research Purpose does not match the Disease-Specific data use limitations.";
+  private static final String POA_F1 = "The Populations, Origins, Ancestry Research Purpose does not match the HMB or Disease-Specific data use limitation.";
+  private static final String NCU_F1 = "The Commercial Use Research Purpose does not match the No Commercial Use data use limitation.";
+
+  // rationale for approvals - based on dataset terms
+  private static final String DS_APPROVE_GRU = "The proposed disease-specific research is within the bounds of the general research use permissions of the dataset(s)";
+  private static final String DS_APPROVE_HMB = "The proposed disease-specific research is within the bounds of the health, medical, biomedical use permissions of the dataset(s)";
+  private static final String HMB_APPROVE_HMB = "The proposed health, medical, biomedical research is within the bounds of the health, medical, biomedical use permissions of the dataset(s)";
+  private static final String HMB_APPROVE_GRU = "The proposed health, medical, biomedical research is within the bounds of the general research use permissions of the dataset(s)";
+  private static final String POA_APPROVE_GRU = "The proposed population, origins, and/or ancestry research is within the bounds of the general research use permissions of the dataset(s)";
+  private static final String POA_APPROVE_POA = "The proposed population, origins, and/or ancestry research is within the bounds of the population, origins, and/or ancestry use permissions of the dataset(s)";
+  private static final String MDS_APPROVE = "Methods research is permitted on controlled-access data so long as it is not expressly prohibited";
+
+  // rationale for abstain cases
+  private static final String ABSTAIN = "The Research Purpose does not result in DUOS Decision.";
+
+  /**
+   * RP: Disease Focused Research Future use is limited to research involving the following disease
+   * area(s) [DS] Datasets: Any dataset with GRU=true Any dataset with HMB=true Any dataset tagged
+   * to this disease exactly Any dataset tagged to a DOID ontology Parent of disease X Denied
+   * Datasets: Any dataset NOT the DS- or a subclass
+   *
+   * @param purpose             The data use object representing the Research Purpose
+   * @param dataset             The data use object representing the Dataset
+   * @param purposeDiseaseIdMap is a map of each purpose term id to a list of that term's parent
+   *                            term ids
+   */
+  static MatchResult matchDiseases(
+      DataUseV4 purpose, DataUseV4 dataset, Map<String, List<String>> purposeDiseaseIdMap) {
+
+    boolean purposeDSX = getNullableOrFalse(!purpose.getDiseaseRestrictions().isEmpty());
+    boolean datasetDSX = getNullableOrFalse(!dataset.getDiseaseRestrictions().isEmpty());
+    boolean datasetGRU = getNullableOrFalse(dataset.getGeneralUse());
+    boolean datasetHMB = getNullableOrFalse(dataset.getHmbResearch());
+
+    // short-circuit if no disease focused research
+    if (!purposeDSX && !datasetDSX) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.emptyList());
+    }
+    // Approve dataset GRU condition
+    if (purposeDSX && datasetGRU) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(DS_APPROVE_GRU));
+    }
+    // Approve dataset HMB condition
+    if (purposeDSX && datasetHMB) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(DS_APPROVE_HMB));
+    }
+
+    // We want all-purpose disease IDs to be a subclass of any dataset disease ID
+    List<String> failures = new ArrayList<>();
+    for (Map.Entry<String, List<String>> entry : purposeDiseaseIdMap.entrySet()) {
+      boolean match = entry.getValue()
+          .stream()
+          .anyMatch(dataset.getDiseaseRestrictions()::contains);
+      if (!match) {
+        failures.add(String.format(DS_F2, entry.getKey()));
+      }
+    }
+
+    return MatchResult.from(failures.isEmpty() ? MatchResultType.APPROVE : MatchResultType.DENY,
+        failures);
+  }
+
+  /**
+   * RP: HMB Approved Datasets: Any dataset tagged with GRU Any dataset tagged with HMB Denied
+   * Datasets: Any dataset tagged with DS- Any dataset tagged with POA
+   *
+   * @param purpose The data use object representing the Research Purpose
+   * @param dataset The data use object representing the Dataset
+   */
+  static MatchResult matchHMB(DataUseV4 purpose, DataUseV4 dataset) {
+    // short-circuit hmb if not set
+    if (Objects.isNull(purpose.getHmbResearch()) && (Objects.isNull(dataset.getHmbResearch()))) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.emptyList());
+    }
+
+    List<String> failures = new ArrayList<>();
+    boolean purposeGRU = getNullableOrFalse(purpose.getGeneralUse());
+    boolean purposeHMB = getNullableOrFalse(purpose.getHmbResearch());
+    boolean datasetGRU = getNullableOrFalse(dataset.getGeneralUse());
+    boolean datasetHMB = getNullableOrFalse(dataset.getHmbResearch());
+    boolean datasetDSX = getNullableOrFalse(!dataset.getDiseaseRestrictions().isEmpty());
+    boolean datasetPOA = getNullableOrFalse(dataset.getPopulationOriginsAncestry());
+
+    // Deny purpose GRU condition
+    if (datasetHMB && purposeGRU) {
+      failures.add(HMB_F1);
+    }
+
+    // Deny dataset DS- condition
+    if (purposeHMB && datasetDSX) {
+      failures.add(HMB_F2);
+    }
+
+    // Deny dataset POA condition
+    if (purposeHMB && datasetPOA) {
+      failures.add(HMB_F3);
+    }
+
+    // Approve dataset GRU condition
+    if (datasetGRU) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(HMB_APPROVE_GRU));
+    }
+
+    // Approve dataset HMB condition
+    if (purposeHMB && datasetHMB) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(HMB_APPROVE_HMB));
+    } else {
+
+      return MatchResult.from(failures.isEmpty() ? MatchResultType.APPROVE : MatchResultType.DENY,
+          failures);
+    }
+  }
+
+  /**
+   * RP: Study population origins or ancestry Future use is limited to research involving a specific
+   * population [POA] Approved Datasets: Any dataset tagged with GRU Any dataset tagged with POA
+   * Denied Datasets: Any dataset tagged with DS- Any dataset tagged with HMB
+   */
+  static MatchResult matchPOA(DataUseV4 purpose, DataUseV4 dataset) {
+    // short-circuit if no POA clause
+    if (Objects.isNull(purpose.getPopulationOriginsAncestry())) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.emptyList());
+    }
+
+    boolean purposePOA = getNullableOrFalse(purpose.getPopulationOriginsAncestry());
+    boolean datasetPOA = getNullableOrFalse(dataset.getPopulationOriginsAncestry());
+    boolean datasetGRU = getNullableOrFalse(dataset.getGeneralUse());
+
+    // Approve dataset GRU condition
+    if (datasetGRU) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(POA_APPROVE_GRU));
+    }
+
+    // Approve dataset POA condition
+    if (purposePOA && datasetPOA) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(POA_APPROVE_POA));
+    }
+
+    List<String> failures = new ArrayList<>();
+    if (!(purpose.getPopulationOriginsAncestry() &&
+        getNullableOrFalse(dataset.getGeneralUse()))) {
+      failures.add(POA_F1);
+    }
+
+    return MatchResult.from(MatchResultType.DENY, failures);
+  }
+
+  /**
+   * RP: Methods development/Validation study Future use for methods research
+   * (analytic/software/technology development) outside the bounds of the other specified
+   * restrictions Approved Datasets: Any dataset where GRU = true Any dataset where HMB = true Any
+   * dataset where POA = true Any dataset where DS-X match
+   */
+  static MatchResult matchMDS(DataUseV4 purpose, DataUseV4 dataset, MatchResultType diseaseMatch) {
+    // short-circuit if no disease focused research
+    if (purpose.getDiseaseRestrictions().isEmpty() && dataset.getDiseaseRestrictions().isEmpty()) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.emptyList());
+    }
+
+    // short-circuit if no MDS clause or if MDS is false
+    if ((Objects.isNull(purpose.getMethodsResearch())) || (!purpose.getMethodsResearch())) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.emptyList());
+    }
+
+    boolean purposeMDS = getNullableOrFalse(purpose.getMethodsResearch());
+    boolean datasetGRU = getNullableOrFalse(dataset.getGeneralUse());
+    boolean datasetHMB = getNullableOrFalse(dataset.getHmbResearch());
+    boolean datasetPOA = getNullableOrFalse(dataset.getPopulationOriginsAncestry());
+
+    // Approve dataset GRU condition
+    if (datasetGRU) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(MDS_APPROVE));
+    }
+
+    // Approve dataset HMB condition
+    if (purposeMDS && datasetHMB) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(MDS_APPROVE));
+    }
+
+    // Approve dataset POA condition
+    if (purposeMDS && datasetPOA) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(MDS_APPROVE));
+    }
+
+    // short-circuit if there is a disease match
+    if (diseaseMatch == MatchResultType.APPROVE) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.singletonList(MDS_APPROVE));
+    } else {
+      return MatchResult.from(MatchResultType.DENY, Collections.singletonList(MDS_F1));
+    }
+  }
+
+  /**
+   * RP: Commercial purpose/by a commercial entity Future commercial use is prohibited [NCU] Future
+   * use by for-profit entities is prohibited [NPU] Approved Datasets: Any dataset where NPU and NCU
+   * are both false Denied Datasets: Any dataset tagged with NCU Any dataset tagged with NPU
+   */
+  static MatchResult matchNonProfitUse(DataUseV4 purpose, DataUseV4 dataset) {
+    // short-circuit if no non-profit clauses
+    if (dataset.getNonProfitUse() == null && purpose.getNonProfitUse() == null) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.emptyList());
+    }
+
+    boolean purposeNpu = getNullableOrFalse(purpose.getNonProfitUse());
+    boolean datasetNPU = getNullableOrFalse(dataset.getNonProfitUse());
+    List<String> failures = new ArrayList<>();
+
+    if (purposeNpu != datasetNPU) {
+      failures.add(NCU_F1);
+    }
+
+    // Approve if NPU cases match
+    if (purposeNpu == datasetNPU) {
+      return MatchResult.from(MatchResultType.APPROVE, Collections.emptyList());
+    } else {
+      return MatchResult.from(MatchResultType.DENY, failures);
+    }
+  }
+
+  /**
+   * DUOS Algorithm: Abstain From Decision Due to the variety of sensitive research areas, ethical
+   * reasons, and areas where categorization is not possible, the DUOS system will not render a
+   * decision in any of the cases not addressed in the methods above.
+   * <p>
+   * Abstained RP's: Any RP that is not GRU, DS-X, POA, MDS, Commercial
+   */
+
+  static MatchResult abstainDecision(
+      DataUseV4 purpose, DataUseV4 dataset, Map<String, List<String>> purposeDiseaseIdMap,
+      MatchResultType diseaseMatch) {
+
+    // Immediate Abstain Cases:
+    if (
+        getNullableOrFalse(purpose.getControls()) ||
+            getNullableOrFalse(purpose.getPopulation()) ||
+            Objects.nonNull(purpose.getGender()) ||
+            getNullableOrFalse(purpose.getPediatric()) ||
+            getNullableOrFalse(purpose.getVulnerablePopulations()) ||
+            getNullableOrFalse(purpose.getIllegalBehavior()) ||
+            getNullableOrFalse(purpose.getSexualDiseases()) ||
+            getNullableOrFalse(purpose.getPsychologicalTraits()) ||
+            getNullableOrFalse(purpose.getNotHealth()) ||
+            getNullableOrFalse(purpose.getStigmatizeDiseases())
+    ) {
+      return MatchResult.from(MatchResultType.ABSTAIN, Collections.singletonList(ABSTAIN));
+    }
+
+    // Valid RPs
+    boolean purposeDSX = getNullableOrFalse(!purpose.getDiseaseRestrictions().isEmpty());
+    boolean purposeHMB = getNullableOrFalse(purpose.getHmbResearch());
+    boolean purposePOA = getNullableOrFalse(purpose.getPopulationOriginsAncestry());
+    boolean purposeMDS = getNullableOrFalse(purpose.getMethodsResearch());
+    boolean purposeGRU = getNullableOrFalse(purpose.getGeneralUse());
+    boolean purposeNPUExists = purpose.getNonProfitUse() != null;
+    boolean datasetNPUExists = dataset.getNonProfitUse() != null;
+
+    // If RP is valid then call that method
+    if (purposeDSX) {
+      return matchDiseases(purpose, dataset, purposeDiseaseIdMap);
+    }
+    if (purposeHMB || purposeGRU) {
+      return matchHMB(purpose, dataset);
+    }
+    if (purposePOA) {
+      return matchPOA(purpose, dataset);
+    }
+    if (purposeMDS) {
+      return matchMDS(purpose, dataset, diseaseMatch);
+    }
+    if (purposeNPUExists || datasetNPUExists) {
+      return matchNonProfitUse(purpose, dataset);
+    }
+    return MatchResult.from(MatchResultType.ABSTAIN, Collections.singletonList(ABSTAIN));
+  }
+
+  // Helper Methods
+
+  /**
+   * @param bool nullable boolean value
+   * @return boolean The value, or false otherwise
+   */
+  private static boolean getNullableOrFalse(Boolean bool) {
+    return Optional.ofNullable(bool).orElse(false);
+  }
+
+
+}

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV4.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV4.java
@@ -1,0 +1,76 @@
+package org.broadinstitute.dsde.consent.ontology.datause;
+
+import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCasesV4.abstainDecision;
+import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCasesV4.matchNonProfitUse;
+import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCasesV4.matchDiseases;
+import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCasesV4.matchHMB;
+import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCasesV4.matchMDS;
+import static org.broadinstitute.dsde.consent.ontology.datause.DataUseMatchCasesV4.matchPOA;
+
+import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsde.consent.ontology.model.DataUseV4;
+import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
+import org.broadinstitute.dsde.consent.ontology.util.DataUseUtil;
+
+public class DataUseMatcherV4 {
+
+  private final DataUseUtil dataUseUtil;
+
+  public DataUseMatcherV4() {
+    dataUseUtil = new DataUseUtil();
+  }
+
+  @Inject
+  public void setAutocompleteService(AutocompleteService autocompleteService) {
+    dataUseUtil.setAutocompleteService(autocompleteService);
+  }
+
+  // Matching Algorithm
+  public MatchResult matchPurposeAndDatasetV4(DataUseV4 purpose, DataUseV4 dataset) {
+    Map<String, List<String>> purposeDiseaseIdMap;
+    try {
+      purposeDiseaseIdMap = dataUseUtil.generatePurposeDiseaseIdMap(
+          purpose.getDiseaseRestrictions());
+    } catch (Exception e) {
+      String purposeRestrictions = StringUtils.join(purpose.getDiseaseRestrictions(), ", ");
+      List<String> errors = Arrays.asList(e.getMessage(),
+          "Error found in one of the purpose terms: " + purposeRestrictions);
+      return MatchResult.from(MatchResultType.DENY, errors);
+    }
+
+    MatchResult diseaseMatch = matchDiseases(purpose, dataset, purposeDiseaseIdMap);
+    final List<MatchResult> matchReasons = new ArrayList<>();
+    matchReasons.add(diseaseMatch);
+    matchReasons.add(matchHMB(purpose, dataset));
+    matchReasons.add(matchPOA(purpose, dataset));
+    matchReasons.add(matchMDS(purpose, dataset, diseaseMatch.getMatchResultType()));
+    matchReasons.add(matchNonProfitUse(purpose, dataset));
+    matchReasons.add(
+        abstainDecision(purpose, dataset, purposeDiseaseIdMap, diseaseMatch.getMatchResultType()));
+    final boolean allMatch = matchReasons.stream().
+        map(MatchResult::getMatchResultType).
+        allMatch(rt -> rt.equals(MatchResultType.APPROVE));
+    final boolean anyAbstain = matchReasons.stream().
+        map(MatchResult::getMatchResultType).
+        anyMatch(rt -> rt.equals(MatchResultType.ABSTAIN));
+    final List<String> reasons = matchReasons.stream().
+        map(MatchResult::getMessage).
+        flatMap(Collection::stream).
+        filter(StringUtils::isNotBlank).
+        collect(Collectors.toList());
+    // if all items match, decision is APPROVED
+    // if not, determine whether DENY or ABSTAIN
+    MatchResultType type = allMatch ? MatchResultType.APPROVE :
+        anyAbstain ?
+            MatchResultType.ABSTAIN :
+            MatchResultType.DENY;
+    return MatchResult.from(type, reasons);
+  }
+}

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/MatchV4ResponseEntity.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/datause/MatchV4ResponseEntity.java
@@ -2,15 +2,15 @@ package org.broadinstitute.dsde.consent.ontology.datause;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
-import org.broadinstitute.dsde.consent.ontology.model.DataUseMatchPairV3;
+import org.broadinstitute.dsde.consent.ontology.model.DataUseMatchPairV4;
 
-public class MatchV3ResponseEntity {
+public class MatchV4ResponseEntity {
 
   private final MatchResultType result;
-  private final DataUseMatchPairV3 matchPair;
+  private final DataUseMatchPairV4 matchPair;
   private final List<String> rationale;
 
-  public MatchV3ResponseEntity(MatchResultType result, DataUseMatchPairV3 matchPair,
+  public MatchV4ResponseEntity(MatchResultType result, DataUseMatchPairV4 matchPair,
       List<String> rationale) {
     this.result = result;
     this.matchPair = matchPair;
@@ -28,7 +28,7 @@ public class MatchV3ResponseEntity {
     return this.result;
   }
 
-  public DataUseMatchPairV3 getMatchPair() {
+  public DataUseMatchPairV4 getMatchPair() {
     return this.matchPair;
   }
   public List<String> getRationale() {

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseBuilderV4.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseBuilderV4.java
@@ -1,0 +1,141 @@
+package org.broadinstitute.dsde.consent.ontology.model;
+
+import java.util.List;
+
+/**
+ * Syntactic sugar for creating a DataUseV4 object.
+ */
+public class DataUseBuilderV4 {
+
+  private DataUseV4 du;
+
+  public DataUseBuilderV4() {
+    du = new DataUseV4();
+  }
+
+  public DataUseV4 build() {
+    return du;
+  }
+
+
+  public DataUseBuilderV4 setGeneralUse(Boolean generalUse) {
+    du.setGeneralUse(generalUse);
+    return this;
+  }
+
+  public DataUseBuilderV4 setHmbResearch(Boolean hmbResearch) {
+    du.setHmbResearch(hmbResearch);
+    return this;
+  }
+
+  public DataUseBuilderV4 setDiseaseRestrictions(List<String> diseaseRestrictions) {
+    du.setDiseaseRestrictions(diseaseRestrictions);
+    return this;
+  }
+
+  public DataUseBuilderV4 setPopulationOriginsAncestry(Boolean populationOriginsAncestry) {
+    du.setPopulationOriginsAncestry(populationOriginsAncestry);
+    return this;
+  }
+
+  public DataUseBuilderV4 setNonProfitUse(Boolean nonProfitUse) {
+    du.setNonProfitUse(nonProfitUse);
+    return this;
+  }
+
+  public DataUseBuilderV4 setMethodsResearch(Boolean methodsResearch) {
+    du.setMethodsResearch(methodsResearch);
+    return this;
+  }
+
+  public DataUseBuilderV4 setOther(String other) {
+    du.setOther(other);
+    return this;
+  }
+
+  public DataUseBuilderV4 setSecondaryOther(String secondaryOther) {
+    du.setSecondaryOther(secondaryOther);
+    return this;
+  }
+
+  public DataUseBuilderV4 setEthicsApprovalRequired(Boolean ethicsApprovalRequired) {
+    du.setEthicsApprovalRequired(ethicsApprovalRequired);
+    return this;
+  }
+
+  public DataUseBuilderV4 setCollaboratorRequired(boolean collaboratorRequired) {
+    du.setCollaboratorRequired(collaboratorRequired);
+    return this;
+  }
+
+  public DataUseBuilderV4 setGeographicalRestrictions(String geographicalRestrictions) {
+    du.setGeographicalRestrictions(geographicalRestrictions);
+    return this;
+  }
+
+  public DataUseBuilderV4 setGeneticStudiesOnly(boolean geneticStudiesOnly) {
+    du.setGeneticStudiesOnly(geneticStudiesOnly);
+    return this;
+  }
+
+  public DataUseBuilderV4 setPublicationResults(boolean publicationResults) {
+    du.setPublicationResults(publicationResults);
+    return this;
+  }
+
+  public DataUseBuilderV4 setPublicationMoratorium(String publicationMoratorium) {
+    du.setPublicationMoratorium(publicationMoratorium);
+    return this;
+  }
+
+  public DataUseBuilderV4 setControls(boolean controls) {
+    du.setControls(controls);
+    return this;
+  }
+
+  public DataUseBuilderV4 setGender(String gender) {
+    du.setGender(gender);
+    return this;
+  }
+
+  public DataUseBuilderV4 setPediatric(boolean pediatric) {
+    du.setPediatric(pediatric);
+    return this;
+  }
+
+  public DataUseBuilderV4 setPopulation(boolean population) {
+    du.setPopulation(population);
+    return this;
+  }
+
+  public DataUseBuilderV4 setIllegalBehavior(boolean illegalBehavior) {
+    du.setIllegalBehavior(illegalBehavior);
+    return this;
+  }
+
+  public DataUseBuilderV4 setSexualDiseases(boolean sexualDiseases) {
+    du.setSexualDiseases(sexualDiseases);
+    return this;
+  }
+
+  public DataUseBuilderV4 setStigmatizeDiseases(boolean stigmatizeDiseases) {
+    du.setStigmatizeDiseases(stigmatizeDiseases);
+    return this;
+  }
+
+  public DataUseBuilderV4 setVulnerablePopulations(boolean vulnerablePopulations) {
+    du.setVulnerablePopulations(vulnerablePopulations);
+    return this;
+  }
+
+  public DataUseBuilderV4 setPsychologicalTraits(boolean psychologicalTraits) {
+    du.setPsychologicalTraits(psychologicalTraits);
+    return this;
+  }
+
+  public DataUseBuilderV4 setNotHealth(boolean notHealth) {
+    du.setNotHealth(notHealth);
+    return this;
+  }
+
+}

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseMatchPairV4.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseMatchPairV4.java
@@ -1,0 +1,55 @@
+package org.broadinstitute.dsde.consent.ontology.model;
+
+import com.google.gson.Gson;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+@SuppressWarnings("unused")
+public class DataUseMatchPairV4 {
+
+  private DataUseV4 purpose;
+
+  private DataUseV4 consent;
+
+  public DataUseMatchPairV4() {
+  }
+
+  public DataUseMatchPairV4(DataUseV4 purpose, DataUseV4 consent) {
+    this.purpose = purpose;
+    this.consent = consent;
+  }
+
+  public DataUseV4 getPurpose() {
+    return purpose;
+  }
+
+  public void setPurpose(DataUseV4 purpose) {
+    this.purpose = purpose;
+  }
+
+  public DataUseV4 getConsent() {
+    return consent;
+  }
+
+  public void setConsent(DataUseV4 consent) {
+    this.consent = consent;
+  }
+
+  @Override
+  public String toString() {
+    return new Gson().toJson(this);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof DataUseMatchPairV4 rhs)) {
+      return false;
+    }
+    return new EqualsBuilder()
+        .append(purpose, rhs.purpose)
+        .append(consent, rhs.consent)
+        .isEquals();
+  }
+}

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseV4.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/model/DataUseV4.java
@@ -1,0 +1,518 @@
+package org.broadinstitute.dsde.consent.ontology.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * Data Use Schema V4
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "generalUse",
+    "diseaseRestrictions",
+    "hmbResearch",
+    "populationOriginsAncestry",
+    "methodsResearch",
+    "nonProfitUse",
+    "other",
+    "secondaryOther",
+    "ethicsApprovalRequired",
+    "collaboratorRequired",
+    "geographicalRestrictions",
+    "geneticStudiesOnly",
+    "publicationResults",
+    "publicationMoratorium",
+    "controls",
+    "gender",
+    "pediatric",
+    "population",
+    "illegalBehavior",
+    "sexualDiseases",
+    "stigmatizeDiseases",
+    "vulnerablePopulations",
+    "psychologicalTraits",
+    "notHealth"
+})
+public class DataUseV4 {
+
+  @JsonProperty("generalUse")
+  private Boolean generalUse;
+  @JsonProperty("diseaseRestrictions")
+  private List<String> diseaseRestrictions = new ArrayList<>();
+  @JsonProperty("hmbResearch")
+  private Boolean hmbResearch;
+  @JsonProperty("populationOriginsAncestry")
+  private Boolean populationOriginsAncestry;
+  @JsonProperty("methodsResearch")
+  private Boolean methodsResearch;
+  @JsonProperty("nonProfitUse")
+  private Boolean nonProfitUse;
+  @JsonProperty("other")
+  private String other;
+  @JsonProperty("secondaryOther")
+  private String secondaryOther;
+  @JsonProperty("ethicsApprovalRequired")
+  private Boolean ethicsApprovalRequired;
+  @JsonProperty("collaboratorRequired")
+  private Boolean collaboratorRequired;
+  @JsonProperty("geographicalRestrictions")
+  private String geographicalRestrictions;
+  @JsonProperty("geneticStudiesOnly")
+  private Boolean geneticStudiesOnly;
+  @JsonProperty("publicationResults")
+  private Boolean publicationResults;
+  @JsonProperty("publicationMoratorium")
+  private String publicationMoratorium;
+  @JsonProperty("controls")
+  private Boolean controls;
+  @JsonProperty("gender")
+  private String gender;
+  @JsonProperty("pediatric")
+  private Boolean pediatric;
+  @JsonProperty("population")
+  private Boolean population;
+  @JsonProperty("illegalBehavior")
+  private Boolean illegalBehavior;
+  @JsonProperty("sexualDiseases")
+  private Boolean sexualDiseases;
+  @JsonProperty("stigmatizeDiseases")
+  private Boolean stigmatizeDiseases;
+  @JsonProperty("vulnerablePopulations")
+  private Boolean vulnerablePopulations;
+  @JsonProperty("psychologicalTraits")
+  private Boolean psychologicalTraits;
+  @JsonProperty("notHealth")
+  private Boolean notHealth;
+
+  @JsonProperty("generalUse")
+  public Boolean getGeneralUse() {
+    return generalUse;
+  }
+
+  @JsonProperty("generalUse")
+  public void setGeneralUse(Boolean generalUse) {
+    this.generalUse = generalUse;
+  }
+
+  @JsonProperty("diseaseRestrictions")
+  public List<String> getDiseaseRestrictions() {
+    return diseaseRestrictions;
+  }
+
+  @JsonProperty("diseaseRestrictions")
+  public void setDiseaseRestrictions(List<String> diseaseRestrictions) {
+    this.diseaseRestrictions = diseaseRestrictions;
+  }
+
+  @JsonProperty("hmbResearch")
+  public Boolean getHmbResearch() {
+    return hmbResearch;
+  }
+
+  @JsonProperty("hmbResearch")
+  public void setHmbResearch(Boolean hmbResearch) {
+    this.hmbResearch = hmbResearch;
+  }
+
+  @JsonProperty("populationOriginsAncestry")
+  public Boolean getPopulationOriginsAncestry() {
+    return populationOriginsAncestry;
+  }
+
+  @JsonProperty("populationOriginsAncestry")
+  public void setPopulationOriginsAncestry(Boolean populationOriginsAncestry) {
+    this.populationOriginsAncestry = populationOriginsAncestry;
+  }
+
+  @JsonProperty("methodsResearch")
+  public Boolean getMethodsResearch() {
+    return methodsResearch;
+  }
+
+  @JsonProperty("methodsResearch")
+  public void setMethodsResearch(Boolean methodsResearch) {
+    this.methodsResearch = methodsResearch;
+  }
+
+  @JsonProperty("nonProfitUse")
+  public Boolean getNonProfitUse() {
+    return nonProfitUse;
+  }
+
+  @JsonProperty("nonProfitUse")
+  public void setNonProfitUse(Boolean nonProfitUse) {
+    this.nonProfitUse = nonProfitUse;
+  }
+
+  @JsonProperty("other")
+  public String getOther() {
+    return other;
+  }
+
+  @JsonProperty("other")
+  public void setOther(String other) {
+    this.other = other;
+  }
+
+  @JsonProperty("secondaryOther")
+  public String getSecondaryOther() {
+    return secondaryOther;
+  }
+
+  @JsonProperty("secondaryOther")
+  public void setSecondaryOther(String secondaryOther) {
+    this.secondaryOther = secondaryOther;
+  }
+
+  @JsonProperty("ethicsApprovalRequired")
+  public Boolean getEthicsApprovalRequired() {
+    return ethicsApprovalRequired;
+  }
+
+  @JsonProperty("ethicsApprovalRequired")
+  public void setEthicsApprovalRequired(Boolean ethicsApprovalRequired) {
+    this.ethicsApprovalRequired = ethicsApprovalRequired;
+  }
+
+  @JsonProperty("collaboratorRequired")
+  public Boolean getCollaboratorRequired() {
+    return collaboratorRequired;
+  }
+
+  @JsonProperty("collaboratorRequired")
+  public void setCollaboratorRequired(Boolean collaboratorRequired) {
+    this.collaboratorRequired = collaboratorRequired;
+  }
+
+  @JsonProperty("geographicalRestrictions")
+  public String getGeographicalRestrictions() {
+    return geographicalRestrictions;
+  }
+
+  @JsonProperty("geographicalRestrictions")
+  public void setGeographicalRestrictions(String geographicalRestrictions) {
+    this.geographicalRestrictions = geographicalRestrictions;
+  }
+
+  @JsonProperty("geneticStudiesOnly")
+  public Boolean getGeneticStudiesOnly() {
+    return geneticStudiesOnly;
+  }
+
+  @JsonProperty("geneticStudiesOnly")
+  public void setGeneticStudiesOnly(Boolean geneticStudiesOnly) {
+    this.geneticStudiesOnly = geneticStudiesOnly;
+  }
+
+  @JsonProperty("publicationResults")
+  public Boolean getPublicationResults() {
+    return publicationResults;
+  }
+
+  @JsonProperty("publicationResults")
+  public void setPublicationResults(Boolean publicationResults) {
+    this.publicationResults = publicationResults;
+  }
+
+  @JsonProperty("publicationMoratorium")
+  public String getPublicationMoratorium() {
+    return publicationMoratorium;
+  }
+
+  @JsonProperty("publicationMoratorium")
+  public void setPublicationMoratorium(String publicationMoratorium) {
+    this.publicationMoratorium = publicationMoratorium;
+  }
+
+  @JsonProperty("controls")
+  public Boolean getControls() {
+    return controls;
+  }
+
+  @JsonProperty("controls")
+  public void setControls(Boolean controls) {
+    this.controls = controls;
+  }
+
+  @JsonProperty("gender")
+  public String getGender() {
+    return gender;
+  }
+
+  @JsonProperty("gender")
+  public void setGender(String gender) {
+    this.gender = gender;
+  }
+
+  @JsonProperty("pediatric")
+  public Boolean getPediatric() {
+    return pediatric;
+  }
+
+  @JsonProperty("pediatric")
+  public void setPediatric(Boolean pediatric) {
+    this.pediatric = pediatric;
+  }
+
+  @JsonProperty("population")
+  public Boolean getPopulation() {
+    return population;
+  }
+
+  @JsonProperty("population")
+  public void setPopulation(Boolean population) {
+    this.population = population;
+  }
+
+  @JsonProperty("illegalBehavior")
+  public Boolean getIllegalBehavior() {
+    return illegalBehavior;
+  }
+
+  @JsonProperty("illegalBehavior")
+  public void setIllegalBehavior(Boolean illegalBehavior) {
+    this.illegalBehavior = illegalBehavior;
+  }
+
+  @JsonProperty("sexualDiseases")
+  public Boolean getSexualDiseases() {
+    return sexualDiseases;
+  }
+
+  @JsonProperty("sexualDiseases")
+  public void setSexualDiseases(Boolean sexualDiseases) {
+    this.sexualDiseases = sexualDiseases;
+  }
+
+  @JsonProperty("stigmatizeDiseases")
+  public Boolean getStigmatizeDiseases() {
+    return stigmatizeDiseases;
+  }
+
+  @JsonProperty("stigmatizeDiseases")
+  public void setStigmatizeDiseases(Boolean stigmatizeDiseases) {
+    this.stigmatizeDiseases = stigmatizeDiseases;
+  }
+
+  @JsonProperty("vulnerablePopulations")
+  public Boolean getVulnerablePopulations() {
+    return vulnerablePopulations;
+  }
+
+  @JsonProperty("vulnerablePopulations")
+  public void setVulnerablePopulations(Boolean vulnerablePopulations) {
+    this.vulnerablePopulations = vulnerablePopulations;
+  }
+
+  @JsonProperty("psychologicalTraits")
+  public Boolean getPsychologicalTraits() {
+    return psychologicalTraits;
+  }
+
+  @JsonProperty("psychologicalTraits")
+  public void setPsychologicalTraits(Boolean psychologicalTraits) {
+    this.psychologicalTraits = psychologicalTraits;
+  }
+
+  @JsonProperty("notHealth")
+  public Boolean getNotHealth() {
+    return notHealth;
+  }
+
+  @JsonProperty("notHealth")
+  public void setNotHealth(Boolean notHealth) {
+    this.notHealth = notHealth;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(DataUseV4.class.getName()).append('@')
+        .append(Integer.toHexString(System.identityHashCode(this))).append('[');
+    sb.append("generalUse");
+    sb.append('=');
+    sb.append(((this.generalUse == null) ? "<null>" : this.generalUse));
+    sb.append(',');
+    sb.append("diseaseRestrictions");
+    sb.append('=');
+    sb.append(((this.diseaseRestrictions == null) ? "<null>" : this.diseaseRestrictions));
+    sb.append(',');
+    sb.append("hmbResearch");
+    sb.append('=');
+    sb.append(((this.hmbResearch == null) ? "<null>" : this.hmbResearch));
+    sb.append(',');
+    sb.append("populationOriginsAncestry");
+    sb.append('=');
+    sb.append(
+        ((this.populationOriginsAncestry == null) ? "<null>" : this.populationOriginsAncestry));
+    sb.append(',');
+    sb.append("methodsResearch");
+    sb.append('=');
+    sb.append(((this.methodsResearch == null) ? "<null>" : this.methodsResearch));
+    sb.append(',');
+    sb.append("nonProfitUse");
+    sb.append('=');
+    sb.append(((this.nonProfitUse == null) ? "<null>" : this.nonProfitUse));
+    sb.append(',');
+    sb.append("other");
+    sb.append('=');
+    sb.append(((this.other == null) ? "<null>" : this.other));
+    sb.append(',');
+    sb.append("secondaryOther");
+    sb.append('=');
+    sb.append(((this.secondaryOther == null) ? "<null>" : this.secondaryOther));
+    sb.append(',');
+    sb.append("ethicsApprovalRequired");
+    sb.append('=');
+    sb.append(((this.ethicsApprovalRequired == null) ? "<null>" : this.ethicsApprovalRequired));
+    sb.append(',');
+    sb.append("collaboratorRequired");
+    sb.append('=');
+    sb.append(((this.collaboratorRequired == null) ? "<null>" : this.collaboratorRequired));
+    sb.append(',');
+    sb.append("geographicalRestrictions");
+    sb.append('=');
+    sb.append(((this.geographicalRestrictions == null) ? "<null>" : this.geographicalRestrictions));
+    sb.append(',');
+    sb.append("geneticStudiesOnly");
+    sb.append('=');
+    sb.append(((this.geneticStudiesOnly == null) ? "<null>" : this.geneticStudiesOnly));
+    sb.append(',');
+    sb.append("publicationResults");
+    sb.append('=');
+    sb.append(((this.publicationResults == null) ? "<null>" : this.publicationResults));
+    sb.append(',');
+    sb.append("publicationMoratorium");
+    sb.append('=');
+    sb.append(((this.publicationMoratorium == null) ? "<null>" : this.publicationMoratorium));
+    sb.append(',');
+    sb.append("controls");
+    sb.append('=');
+    sb.append(((this.controls == null) ? "<null>" : this.controls));
+    sb.append(',');
+    sb.append("gender");
+    sb.append('=');
+    sb.append(((this.gender == null) ? "<null>" : this.gender));
+    sb.append(',');
+    sb.append("pediatric");
+    sb.append('=');
+    sb.append(((this.pediatric == null) ? "<null>" : this.pediatric));
+    sb.append(',');
+    sb.append("population");
+    sb.append('=');
+    sb.append(((this.population == null) ? "<null>" : this.population));
+    sb.append(',');
+    sb.append("illegalBehavior");
+    sb.append('=');
+    sb.append(((this.illegalBehavior == null) ? "<null>" : this.illegalBehavior));
+    sb.append(',');
+    sb.append("sexualDiseases");
+    sb.append('=');
+    sb.append(((this.sexualDiseases == null) ? "<null>" : this.sexualDiseases));
+    sb.append(',');
+    sb.append("stigmatizeDiseases");
+    sb.append('=');
+    sb.append(((this.stigmatizeDiseases == null) ? "<null>" : this.stigmatizeDiseases));
+    sb.append(',');
+    sb.append("vulnerablePopulations");
+    sb.append('=');
+    sb.append(((this.vulnerablePopulations == null) ? "<null>" : this.vulnerablePopulations));
+    sb.append(',');
+    sb.append("psychologicalTraits");
+    sb.append('=');
+    sb.append(((this.psychologicalTraits == null) ? "<null>" : this.psychologicalTraits));
+    sb.append(',');
+    sb.append("notHealth");
+    sb.append('=');
+    sb.append(((this.notHealth == null) ? "<null>" : this.notHealth));
+    sb.append(',');
+    if (sb.charAt((sb.length() - 1)) == ',') {
+      sb.setCharAt((sb.length() - 1), ']');
+    } else {
+      sb.append(']');
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result = ((result * 31) + ((this.other == null) ? 0 : this.other.hashCode()));
+    result = ((result * 31) + ((this.nonProfitUse == null) ? 0 : this.nonProfitUse.hashCode()));
+    result = ((result * 31) + ((this.controls == null) ? 0 : this.controls.hashCode()));
+    result = ((result * 31) + ((this.psychologicalTraits == null) ? 0
+        : this.psychologicalTraits.hashCode()));
+    result = ((result * 31) + ((this.gender == null) ? 0 : this.gender.hashCode()));
+    result = ((result * 31) + ((this.geneticStudiesOnly == null) ? 0
+        : this.geneticStudiesOnly.hashCode()));
+    result = ((result * 31) + ((this.generalUse == null) ? 0 : this.generalUse.hashCode()));
+    result = ((result * 31) + ((this.publicationResults == null) ? 0
+        : this.publicationResults.hashCode()));
+    result = ((result * 31) + ((this.diseaseRestrictions == null) ? 0
+        : this.diseaseRestrictions.hashCode()));
+    result = ((result * 31) + ((this.pediatric == null) ? 0 : this.pediatric.hashCode()));
+    result = ((result * 31) + ((this.vulnerablePopulations == null) ? 0
+        : this.vulnerablePopulations.hashCode()));
+    result = ((result * 31) + ((this.methodsResearch == null) ? 0
+        : this.methodsResearch.hashCode()));
+    result = ((result * 31) + ((this.publicationMoratorium == null) ? 0
+        : this.publicationMoratorium.hashCode()));
+    result = ((result * 31) + ((this.sexualDiseases == null) ? 0 : this.sexualDiseases.hashCode()));
+    result = ((result * 31) + ((this.illegalBehavior == null) ? 0
+        : this.illegalBehavior.hashCode()));
+    result = ((result * 31) + ((this.collaboratorRequired == null) ? 0
+        : this.collaboratorRequired.hashCode()));
+    result = ((result * 31) + ((this.populationOriginsAncestry == null) ? 0
+        : this.populationOriginsAncestry.hashCode()));
+    result = ((result * 31) + ((this.ethicsApprovalRequired == null) ? 0
+        : this.ethicsApprovalRequired.hashCode()));
+    result = ((result * 31) + ((this.secondaryOther == null) ? 0 : this.secondaryOther.hashCode()));
+    result = ((result * 31) + ((this.hmbResearch == null) ? 0 : this.hmbResearch.hashCode()));
+    result = ((result * 31) + ((this.geographicalRestrictions == null) ? 0
+        : this.geographicalRestrictions.hashCode()));
+    result = ((result * 31) + ((this.population == null) ? 0 : this.population.hashCode()));
+    result = ((result * 31) + ((this.notHealth == null) ? 0 : this.notHealth.hashCode()));
+    result = ((result * 31) + ((this.stigmatizeDiseases == null) ? 0
+        : this.stigmatizeDiseases.hashCode()));
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof DataUseV4 rhs)) {
+      return false;
+    }
+    return
+        Objects.equals(this.other, rhs.other) && (Objects.equals(this.nonProfitUse,
+        rhs.nonProfitUse)) && (Objects.equals(this.controls, rhs.controls)) && (
+        Objects.equals(this.psychologicalTraits, rhs.psychologicalTraits)) && Objects.equals(
+        this.gender, rhs.gender) && (Objects.equals(this.geneticStudiesOnly,
+        rhs.geneticStudiesOnly)) && (Objects.equals(this.generalUse, rhs.generalUse))
+        && (Objects.equals(this.publicationResults,
+        rhs.publicationResults)) && (Objects.equals(this.diseaseRestrictions,
+        rhs.diseaseRestrictions)) && (Objects.equals(this.pediatric, rhs.pediatric)) && (
+        Objects.equals(this.vulnerablePopulations, rhs.vulnerablePopulations)) && (Objects.equals(
+        this.methodsResearch, rhs.methodsResearch))
+        && Objects.equals(this.publicationMoratorium, rhs.publicationMoratorium) && (
+        Objects.equals(this.sexualDiseases, rhs.sexualDiseases)) && (
+        Objects.equals(this.illegalBehavior, rhs.illegalBehavior)) && (
+        Objects.equals(this.collaboratorRequired, rhs.collaboratorRequired)) && (
+        Objects.equals(this.populationOriginsAncestry, rhs.populationOriginsAncestry)) && (
+        Objects.equals(this.ethicsApprovalRequired, rhs.ethicsApprovalRequired)) && Objects.equals(
+        this.secondaryOther, rhs.secondaryOther) && (Objects.equals(this.hmbResearch,
+        rhs.hmbResearch)) && Objects.equals(this.geographicalRestrictions,
+        rhs.geographicalRestrictions) && (Objects.equals(
+        this.population, rhs.population)) && (Objects.equals(this.notHealth, rhs.notHealth))
+        && (Objects.equals(this.stigmatizeDiseases, rhs.stigmatizeDiseases));
+  }
+
+}
+

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/DataUseResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/DataUseResource.java
@@ -41,12 +41,39 @@ public class DataUseResource implements OntologyLogger {
     return Response.ok().entity(content).type(MediaType.APPLICATION_JSON).build();
   }
 
+  @GET
+  @Path("/data-use/v4")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getSchemaV4() {
+    String content = FileUtils.readAllTextFromResource("data-use-v4.json");
+    return Response.ok().entity(content).type(MediaType.APPLICATION_JSON).build();
+  }
+
   @POST
   @Path("/data-use/v3")
   @Produces(MediaType.APPLICATION_JSON)
   public Response validateSchemaV3(String json) {
     try {
       List<String> errors = jsonSchemaUtil.validateDataUseV3Schema(json);
+      if (errors.isEmpty()) {
+        return Response.ok().type(MediaType.APPLICATION_JSON).build();
+      } else {
+        // nosemgrep
+        return Response.status(HttpStatusCodes.STATUS_CODE_BAD_REQUEST).entity(errors)
+            .type(MediaType.APPLICATION_JSON).build();
+      }
+    } catch (BadRequestException e) {
+        return Response.status(HttpStatusCodes.STATUS_CODE_BAD_REQUEST).entity(e.getMessage())
+            .type(MediaType.APPLICATION_JSON).build();
+    }
+  }
+
+  @POST
+  @Path("/data-use/v4")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response validateSchemaV4(String json) {
+    try {
+      List<String> errors = jsonSchemaUtil.validateDataUseV4Schema(json);
       if (errors.isEmpty()) {
         return Response.ok().type(MediaType.APPLICATION_JSON).build();
       } else {

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/util/JsonSchemaUtil.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/util/JsonSchemaUtil.java
@@ -103,7 +103,7 @@ public class JsonSchemaUtil implements OntologyLogger {
     try {
       ObjectMapper mapper = new ObjectMapper();
       JsonNode jsonSubject = mapper.readTree(dataUseV4Instance);
-      JsonSchema schema = getDataUseV3Instance();
+      JsonSchema schema = getDataUseV4Instance();
       Set<ValidationMessage> messages = schema.validate(jsonSubject);
       return messages.stream().map(ValidationMessage::getMessage).toList();
     } catch (Exception e) {

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -65,6 +65,35 @@ paths:
         400:
           description: Bad Request if data use term is invalid or required terms are missing.
 
+  /schemas/data-use/v4:
+    get:
+      summary: Data Use Questions and Answers Version 4
+      description: JSON representation of data use questions + answers for use in defining structured data use restrictions and data access requests.
+      tags:
+        - Data Use
+      responses:
+        200:
+          description: The json representation for all data use questions + answers
+        default:
+          description: Unexpected error
+    post:
+      summary: Validate Data Use Terms
+      description: Checks if the Data Use terms has the correct format and context
+      parameters:
+        - name: body
+          in: body
+          description: DataUseV4
+          required: true
+          schema:
+            $ref: '#/definitions/DataUseV4'
+      tags:
+        - Data Use
+      responses:
+        200:
+          description: Successful.
+        400:
+          description: Bad Request if data use term is invalid or required terms are missing.
+
   /translate:
     post:
       summary: Translate Data Use JSON into plain English
@@ -179,6 +208,29 @@ paths:
           description: Successful matching.
           schema:
             $ref: '#/definitions/DataUseMatchPairResultV3'
+        400:
+          description: Bad Request if either purpose or consent are not provided.
+        500:
+          description: Internal Server Error
+
+  /match/v4:
+    post:
+      summary: Match DataUse Purpose and Consent V4
+      description: Determine if a Research Purpose and Consent logically match.
+      parameters:
+        - name: body
+          in: body
+          description: Research Purpose and Dataset DataUse pair.
+          required: true
+          schema:
+            $ref: '#/definitions/DataUseMatchPairV4'
+      tags:
+        - Match
+      responses:
+        200:
+          description: Successful matching.
+          schema:
+            $ref: '#/definitions/DataUseMatchPairResultV4'
         400:
           description: Bad Request if either purpose or consent are not provided.
         500:
@@ -336,6 +388,12 @@ definitions:
     example:
       { "generalUse": false, "hmbResearch": true, "nonProfitUse": false }
 
+  DataUseV4:
+    type: object
+    description: JSON model of a set of data use questions and answers
+    example:
+      { "generalUse": false, "hmbResearch": true, "nonProfitUse": false }
+
   DataUseRecommendation:
     type: object
     description: JSON model of a set of data use recommendations
@@ -377,6 +435,15 @@ definitions:
       consent:
         $ref: '#/definitions/DataUseV3'
 
+  DataUseMatchPairV4:
+    type: object
+    description: JSON model of research purpose and dataset
+    properties:
+      purpose:
+        $ref: '#/definitions/DataUseV4'
+      consent:
+        $ref: '#/definitions/DataUseV4'
+
   DataUseMatchPairResultV3:
     type: object
     properties:
@@ -386,6 +453,24 @@ definitions:
         description: Result of the match algorithm on the provided purpose and dataset
       matchPair:
         $ref: '#/definitions/DataUseMatchPairV3'
+        description: The provided purpose and consent
+      rationale:
+        type: array
+        items:
+          type: string
+        description: |
+          List of reasons why a match result occurred. Only supported in
+          in versions 2 and higher
+
+  DataUseMatchPairResultV4:
+    type: object
+    properties:
+      result:
+        type: string
+        enum: [APPROVE, DENY, ABSTAIN]
+        description: Result of the match algorithm on the provided purpose and dataset
+      matchPair:
+        $ref: '#/definitions/DataUseMatchPairV4'
         description: The provided purpose and consent
       rationale:
         type: array

--- a/src/main/resources/data-use-v4.json
+++ b/src/main/resources/data-use-v4.json
@@ -1,0 +1,133 @@
+{
+  "$id" : "https://consent-ontology.dsde-prod.broadinstitute.org/schemas/data-use",
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "Data Use Schema V3",
+  "version" : 4,
+  "type" : "object",
+  "anyOf" : [
+    {
+      "required" : [
+        "generalUse"
+      ]
+    },
+    {
+      "required" : [
+        "diseaseRestrictions"
+      ]
+    },
+    {
+      "required" : [
+        "hmbResearch"
+      ]
+    }
+  ],
+  "properties" : {
+    "generalUse" : {
+      "type" : "boolean",
+      "consentDescription" : "General Research Use"
+    },
+    "diseaseRestrictions" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "uniqueItems" : true
+      },
+      "purposeDescription" : "Is the primary purpose of this research to investigate a specific disease(s)?",
+      "consentDescription" : "Disease-Specific Research Use"
+    },
+    "hmbResearch" : {
+      "type" : "boolean",
+      "purposeDescription" : "Is the primary purpose health/medical/biomedical research in nature?",
+      "consentDescription" : "Health/Medical/Biomedical Research Use"
+    },
+    "populationOriginsAncestry" : {
+      "type" : "boolean",
+      "purposeDescription" : "Is the primary purpose of this research regarding population origins or ancestry?",
+      "consentDescription" : "Populations, Origins, Ancestry Use"
+    },
+    "methodsResearch" : {
+      "type" : "boolean",
+      "purposeDescription" : "Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?",
+      "consentDescription" : "No methods development or validation studies (NMDS)"
+    },
+    "nonProfitUse" : {
+      "type" : "boolean",
+      "consentDescription" : "Non-profit Use Only (NPU)"
+    },
+    "other" : {
+      "type" : "string",
+      "purposeDescription" : "Other",
+      "consentDescription" : "Other"
+    },
+    "secondaryOther" : {
+      "type" : "string",
+      "purposeDescription" : "Other",
+      "consentDescription" : "Other"
+    },
+    "ethicsApprovalRequired" : {
+      "type" : "boolean",
+      "consentDescription" : "Ethics Approval Required (IRB)"
+    },
+    "collaboratorRequired" : {
+      "type" : "boolean",
+      "consentDescription" : "Collaboration Required (COL)"
+    },
+    "geographicalRestrictions" : {
+      "type" : "string",
+      "consentDescription" : "Geographic Restriction (GS-)"
+    },
+    "geneticStudiesOnly" : {
+      "type" : "boolean",
+      "consentDescription" : "Genetic studies only (GSO)"
+    },
+    "publicationResults" : {
+      "type" : "boolean",
+      "consentDescription" : "Publication Required (PUB)"
+    },
+    "publicationMoratorium" : {
+      "type" : "string",
+      "format" : "date",
+      "consentDescription" : "Publication Moratorium (MOR)"
+    },
+    "controls" : {
+      "type" : "boolean",
+      "purposeDescription" : "Increase controls available for a comparison group (e.g. a case-control study)."
+    },
+    "gender" : {
+      "type" : "string",
+      "purposeDescription" : "Limited to one gender"
+    },
+    "pediatric" : {
+      "type" : "boolean",
+      "purposeDescription" : "Limited to a pediatric population (under the age of 18)"
+    },
+    "population" : {
+      "type" : "boolean",
+      "purposeDescription" : "Study variation in the general population (e.g. calling variants and/or studying their distribution)."
+    },
+    "illegalBehavior" : {
+      "type" : "boolean",
+      "purposeDescription" : "Illegal behaviors (violence, domestic abuse, prostitution, sexual victimization)"
+    },
+    "sexualDiseases" : {
+      "type" : "boolean",
+      "purposeDescription" : "Sexual preferences or sexually transmitted diseases"
+    },
+    "stigmatizeDiseases" : {
+      "type" : "boolean",
+      "purposeDescription" : "Stigmatizing illnesses"
+    },
+    "vulnerablePopulations" : {
+      "type" : "boolean",
+      "purposeDescription" : "Targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [“SIGNIFICANTLY”] economically or educationally disadvantaged persons)"
+    },
+    "psychologicalTraits" : {
+      "type" : "boolean",
+      "purposeDescription" : "Psychological traits, intelligence, or attention"
+    },
+    "notHealth" : {
+      "type" : "boolean",
+      "purposeDescription" : "Correlating ethnicity, race, or gender with genotypic or phenotypic variables for purposes beyond biomedical or health-related research, or in ways not easily related to health"
+    }
+  }
+}

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV4Test.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV4Test.java
@@ -212,17 +212,18 @@ public class DataUseMatcherV4Test {
     assertApprove(purpose, dataset);
   }
 
+  // This is a confusing case. When a dataset NPU == false, that means there are effectively NO
+  // NPU restrictions on it. That means that any purpose NPU == true|false should be approved.
+  @Test
+  public void testNPU_positive_case_3() {
+    DataUseV4 dataset = new DataUseBuilderV4().setNonProfitUse(false).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setNonProfitUse(true).build();
+    assertApprove(purpose, dataset);
+  }
   @Test
   public void testNPU_negative_case_1() {
     DataUseV4 dataset = new DataUseBuilderV4().setNonProfitUse(true).build();
     DataUseV4 purpose = new DataUseBuilderV4().setNonProfitUse(false).build();
-    assertDeny(purpose, dataset);
-  }
-
-  @Test
-  public void testNPU_negative_case_2() {
-    DataUseV4 dataset = new DataUseBuilderV4().setNonProfitUse(false).build();
-    DataUseV4 purpose = new DataUseBuilderV4().setNonProfitUse(true).build();
     assertDeny(purpose, dataset);
   }
 

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV4Test.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/datause/DataUseMatcherV4Test.java
@@ -1,0 +1,349 @@
+package org.broadinstitute.dsde.consent.ontology.datause;
+
+import static org.broadinstitute.dsde.consent.ontology.datause.MatchResultType.Abstain;
+import static org.broadinstitute.dsde.consent.ontology.datause.MatchResultType.Approve;
+import static org.broadinstitute.dsde.consent.ontology.datause.MatchResultType.Deny;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.broadinstitute.dsde.consent.ontology.model.DataUseBuilderV4;
+import org.broadinstitute.dsde.consent.ontology.model.DataUseV4;
+import org.broadinstitute.dsde.consent.ontology.model.TermParent;
+import org.broadinstitute.dsde.consent.ontology.model.TermResource;
+import org.broadinstitute.dsde.consent.ontology.service.AutocompleteService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class DataUseMatcherV4Test {
+
+  private static final String cancerNode = "http://purl.obolibrary.org/obo/DOID_162";
+  private static final String intestinalCancerNode = "http://purl.obolibrary.org/obo/DOID_10155";
+
+  @Mock
+  private AutocompleteService autocompleteService;
+
+  @BeforeEach
+  public void setUp() {
+    openMocks(this);
+    try {
+      when(autocompleteService.lookupById(any())).thenReturn(Collections.emptyList());
+    } catch (Exception e) {
+      //
+    }
+  }
+
+  @Test
+  public void testDiseaseMatching_positive() throws Exception {
+    DataUseV4 dataset = new DataUseBuilderV4()
+        .setDiseaseRestrictions(Collections.singletonList(cancerNode))
+        .build();
+    DataUseV4 purpose = new DataUseBuilderV4()
+        .setDiseaseRestrictions(Collections.singletonList(intestinalCancerNode))
+        .build();
+    // Build a mock response of term parents based on what is returned when searching on DOID_10155
+    List<TermResource> termResources = new ArrayList<>();
+    TermResource resource = new TermResource();
+    TermParent parent1 = new TermParent();
+    parent1.setId("http://purl.obolibrary.org/obo/DOID_3119");
+    TermParent parent2 = new TermParent();
+    parent2.setId("http://purl.obolibrary.org/obo/DOID_0050686");
+    TermParent parent3 = new TermParent();
+    parent3.setId("http://purl.obolibrary.org/obo/DOID_162");
+    TermParent parent4 = new TermParent();
+    parent4.setId("http://purl.obolibrary.org/obo/DOID_14566");
+    TermParent parent5 = new TermParent();
+    parent5.setId("http://purl.obolibrary.org/obo/DOID_4");
+
+    resource.setId(intestinalCancerNode);
+    resource.setParents(new ArrayList<>());
+    resource.getParents().add(parent1);
+    resource.getParents().add(parent2);
+    resource.getParents().add(parent3);
+    resource.getParents().add(parent4);
+    resource.getParents().add(parent5);
+
+    termResources.add(resource);
+
+    when(autocompleteService.lookupById(intestinalCancerNode)).thenReturn(termResources);
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testDiseaseMatching_negative() throws Exception {
+    DataUseV4 dataset = new DataUseBuilderV4()
+        .setDiseaseRestrictions(Collections.singletonList(intestinalCancerNode))
+        .build();
+    DataUseV4 purpose = new DataUseBuilderV4()
+        .setDiseaseRestrictions(Collections.singletonList(cancerNode))
+        .build();
+
+    // Build a mock response of term parents based on what is returned when searching on DOID_162
+    List<TermResource> termResources = new ArrayList<>();
+    TermResource resource = new TermResource();
+    TermParent parent1 = new TermParent();
+    parent1.setId("http://purl.obolibrary.org/obo/DOID_14566");
+    TermParent parent2 = new TermParent();
+    parent2.setId("http://purl.obolibrary.org/obo/DOID_4");
+
+    resource.setId(cancerNode);
+    resource.setParents(new ArrayList<>());
+    resource.getParents().add(parent1);
+    resource.getParents().add(parent2);
+
+    termResources.add(resource);
+
+    when(autocompleteService.lookupById(cancerNode)).thenReturn(termResources);
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testHMB_positive_case_1() {
+    DataUseV4 dataset = new DataUseBuilderV4().setGeneralUse(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testHMB_positive_case_2() {
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testHMB_negative_case_1() {
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setGeneralUse(true).build();
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testHMB_negative_case_2() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setDiseaseRestrictions(
+        Collections.singletonList(cancerNode)).build();
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testHMB_negative_case_3() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setPopulationOriginsAncestry(true).build();
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testPOA_positive_case_1() {
+    DataUseV4 dataset = new DataUseBuilderV4().setGeneralUse(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setPopulationOriginsAncestry(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testPOA_positive_case_2() {
+    DataUseV4 dataset = new DataUseBuilderV4().setPopulationOriginsAncestry(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setPopulationOriginsAncestry(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testPOA_negative_case_1() {
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setPopulationOriginsAncestry(true).build();
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testPOA_negative_case_2() {
+    DataUseV4 dataset = new DataUseBuilderV4()
+        .setDiseaseRestrictions(Collections.singletonList(cancerNode))
+        .build();
+    DataUseV4 purpose = new DataUseBuilderV4().setPopulationOriginsAncestry(true).build();
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testMDS_positive_case_1() {
+    DataUseV4 dataset = new DataUseBuilderV4().setGeneralUse(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setMethodsResearch(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testMDS_positive_case_2() {
+    DataUseV4 dataset = new DataUseBuilderV4().setPopulationOriginsAncestry(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setMethodsResearch(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testMDS_positive_case_3() {
+    DataUseV4 dataset = new DataUseBuilderV4().setDiseaseRestrictions(
+        Collections.singletonList(cancerNode)).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setMethodsResearch(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testMDS_positive_case_4() {
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setMethodsResearch(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testNPU_positive_case_1() {
+    DataUseV4 dataset = new DataUseBuilderV4().setNonProfitUse(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setNonProfitUse(true).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testNPU_positive_case_2() {
+    DataUseV4 dataset = new DataUseBuilderV4().setNonProfitUse(false).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setNonProfitUse(false).build();
+    assertApprove(purpose, dataset);
+  }
+
+  @Test
+  public void testNPU_negative_case_1() {
+    DataUseV4 dataset = new DataUseBuilderV4().setNonProfitUse(true).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setNonProfitUse(false).build();
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testNPU_negative_case_2() {
+    DataUseV4 dataset = new DataUseBuilderV4().setNonProfitUse(false).build();
+    DataUseV4 purpose = new DataUseBuilderV4().setNonProfitUse(true).build();
+    assertDeny(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_COL() {
+    DataUseV4 purpose = new DataUseBuilderV4().setCollaboratorRequired(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_Other() {
+    DataUseV4 purpose = new DataUseBuilderV4().setOther("other").build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_SecondaryOther() {
+    DataUseV4 purpose = new DataUseBuilderV4().setSecondaryOther("secondary other").build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_ethicsApprovalRequired() {
+    DataUseV4 purpose = new DataUseBuilderV4().setEthicsApprovalRequired(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_controls() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setControls(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_population() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setPopulation(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_gender() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setGender("M").build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_pediatric() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setPediatric(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_vulnerablePopulations() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setVulnerablePopulations(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_illegalBehavior() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setIllegalBehavior(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_sexualDiseases() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setSexualDiseases(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_psychologicalTraits() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setPsychologicalTraits(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_notHealth() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setNotHealth(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  @Test
+  public void testAbstainDecision_stigmatizedDiseases() {
+    DataUseV4 purpose = new DataUseBuilderV4().setHmbResearch(true).setStigmatizeDiseases(true).build();
+    DataUseV4 dataset = new DataUseBuilderV4().setHmbResearch(true).build();
+    assertAbstain(purpose, dataset);
+  }
+
+  private void assertApprove(DataUseV4 purpose, DataUseV4 dataset) {
+    MatchResult match = matchPurposeAndDataset(purpose, dataset);
+    assertTrue(Approve(match.getMatchResultType()));
+  }
+
+  private void assertDeny(DataUseV4 purpose, DataUseV4 dataset) {
+    MatchResult match = matchPurposeAndDataset(purpose, dataset);
+    assertTrue(Deny(match.getMatchResultType()));
+    assertFalse(match.getMessage().isEmpty());
+  }
+
+  private void assertAbstain(DataUseV4 purpose, DataUseV4 dataset) {
+    MatchResult match = matchPurposeAndDataset(purpose, dataset);
+    assertTrue(Abstain(match.getMatchResultType()));
+    assertFalse(match.getMessage().isEmpty());
+  }
+
+  private MatchResult matchPurposeAndDataset(DataUseV4 purpose, DataUseV4 dataset) {
+    DataUseMatcherV4 matcher = new DataUseMatcherV4();
+    matcher.setAutocompleteService(autocompleteService);
+    return matcher.matchPurposeAndDatasetV4(purpose, dataset);
+  }
+}

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/MatchResourceTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/MatchResourceTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.broadinstitute.dsde.consent.ontology.datause.DataUseMatcher;
 import org.broadinstitute.dsde.consent.ontology.datause.DataUseMatcherV3;
+import org.broadinstitute.dsde.consent.ontology.datause.DataUseMatcherV4;
 import org.broadinstitute.dsde.consent.ontology.datause.MatchResult;
 import org.broadinstitute.dsde.consent.ontology.datause.MatchResultType;
 import org.broadinstitute.dsde.consent.ontology.datause.MatchV3ResponseEntity;
@@ -39,6 +40,9 @@ public class MatchResourceTest {
   @Mock
   private final DataUseMatcherV3 dataUseMatcherV3 = new DataUseMatcherV3();
 
+  @Mock
+  private final DataUseMatcherV4 dataUseMatcherV4 = new DataUseMatcherV4();
+
   private MatchResource resource;
 
   @BeforeEach
@@ -58,7 +62,7 @@ public class MatchResourceTest {
 
   private void initResource() {
     dataUseMatcher.setAutocompleteService(autocompleteService);
-    resource = new MatchResource(dataUseMatcher, dataUseMatcherV3);
+    resource = new MatchResource(dataUseMatcher, dataUseMatcherV3, dataUseMatcherV4);
   }
 
   @Test


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2931

### Summary
* Add a new set of endpoints for retrieving, validating and matching on a new V4 matching algorithm
* Adds documentation for the new algorithm
* This is essentially a copy of the V3 algorithm except that it drops `commercialUse` and relies explicitly on `nonProfitUse`
* Includes a minor bug fix (in V3) to remove duplicate reasons from the list of match reasons.

The primary documentation change is:

![Screenshot 2024-02-15 at 4 49 56 PM](https://github.com/DataBiosphere/consent-ontology/assets/116679/571b63f6-174a-414a-9909-7aed9ffa989a)


----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
