### PR TITLE
[DUOS-1740][risk=no] Remove unnecessary download plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,25 +279,6 @@
       </plugin>
 
       <plugin>
-        <groupId>com.googlecode.maven-download-plugin</groupId>
-        <artifactId>download-maven-plugin</artifactId>
-        <version>1.9.0</version>
-        <executions>
-          <execution>
-            <id>swagger-ui</id>
-            <goals>
-              <goal>wget</goal>
-            </goals>
-            <configuration>
-              <url>https://github.com/swagger-api/swagger-ui/archive/v${swagger.ui.version}.tar.gz
-              </url>
-              <unpack>true</unpack>
-              <outputDirectory>${project.build.directory}</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.3.1</version>
         <executions>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

### Summary
The plugin that downloads swagger is not necessary.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
