### PR TITLE
[DCJ-28][risk=no] Use Sherlock to Slack DCJ team on smoke test failures, retries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,17 +57,6 @@ jobs:
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}
-    - name: Notify Slack
-      # only notify for develop branch build
-      if: github.event_name == 'push'
-      uses: broadinstitute/action-slack@v3.15.0
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        status: ${{ job.status }}
-        channel: "#duos-notifications"
-        fields: repo,commit,author,action,eventName,ref,workflow,job,took
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: [ tag-build-push ]

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -49,15 +49,6 @@ jobs:
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}}
           inputs: '{ "bee-name": "${{ steps.setup.outputs.bee-name }}" }'
-      - name: Notify Slack
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          status: ${{ job.status }}
-          channel: "#duos-notifications"
-          fields: repo,commit,author,action,eventName,ref,workflow,job,took
 
   upload-test-reports:
     needs: [smoke-tests]
@@ -73,3 +64,12 @@ jobs:
       artifact: 'test-reports'
       big-query-table: 'broad-dsde-qa.automated_testing.test_results'
       subuuid: ${{ github.run_id }}
+
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    with:
+      relates-to-chart-releases: 'ontology-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+    permissions:
+      id-token: write


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-28

### Summary

Previously this emitted a Slack alert to #duos-alerts on each run.

The Slack channel list is configured via a GHA repo variable, so can be tweaked without code changes if needed.

<img width="1355" alt="Screenshot 2024-04-23 at 10 41 09 AM" src="https://github.com/DataBiosphere/consent-ontology/assets/79769153/7ba198cd-7371-4901-8d4f-2ff8c05beb7e">

Also removed the Slack alert from 'Tag, Build and Push Image': we get insight into deployment status from an existing [Beehive Slack deploy hook on ontology-dev](https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/ontology/deploy-hooks/slack/26), but we should repoint this alert to the DCJ channel.

More complete background: https://github.com/DataBiosphere/jade-data-repo/pull/1654

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
