### PR TITLE
[DUOS-3070][risk=no] Bug Fix: revert to v3 of upload-artifact action

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mvn clean test -P integration-tests -DbaseUrl=https://ontology.${{ steps.setup.outputs.bee-name }}.bee.envs-terra.bio/
       - name: Store Test Result Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: test-reports


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3070

### Summary
* Revert version to v3, v4 is incompatible with our usage

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
