### PR TITLE
[DUOS-3064][risk=no] Update smoke tests to match current changes

### DIFF
--- a/src/test/java/org/broadinstitute/integration/MatchTests.java
+++ b/src/test/java/org/broadinstitute/integration/MatchTests.java
@@ -3,6 +3,7 @@ package org.broadinstitute.integration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.api.client.http.HttpStatusCodes;
+import jakarta.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -25,12 +26,19 @@ class MatchTests implements IntegrationTestHelper {
   @Test
   void ontology_match_v2_page_OK() throws Exception {
     SimpleResponse response = getPostResponse("match/v2", matchPair);
-    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.code());
+    assertEquals(Status.GONE.getStatusCode(), response.code());
   }
 
   @DisplayName("Match V3: OK test")
   @Test
   void ontology_match_v3_page_OK() throws Exception {
+    SimpleResponse response = getPostResponse("match/v3", matchPair);
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.code());
+  }
+
+  @DisplayName("Match V4: OK test")
+  @Test
+  void ontology_match_v4_page_OK() throws Exception {
     SimpleResponse response = getPostResponse("match/v3", matchPair);
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, response.code());
   }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3064

### Summary
Related to https://github.com/DataBiosphere/consent-ontology/pull/940
This fixes the mismatch in API expectations

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
