### PR TITLE
DCJ-41, DCJ-169 Smoke Test Updates

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           mvn clean test -P integration-tests -DbaseUrl=https://ontology.${{ steps.setup.outputs.bee-name }}.bee.envs-terra.bio/
       - name: Store Test Result Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-reports

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -68,6 +68,7 @@ jobs:
       subuuid: ${{ github.run_id }}
 
   report-workflow:
+    if: github.ref == 'refs/heads/develop'
     uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
     with:
       relates-to-chart-releases: 'ontology-dev'

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   smoke-tests:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -1,9 +1,12 @@
 name: ontology-smoke-tests
 
 on:
+  push:
+    branches:
+      - develop
   pull_request:
-    types:
-      - closed
+    branches:
+      - develop
 
 jobs:
   smoke-tests:


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-41
https://broadworkbench.atlassian.net/browse/DCJ-169

### Summary
* Run smoke tests similarly to how we run unit tests
* Un-revert the [v4->v3 action downgrade](https://github.com/DataBiosphere/consent-ontology/pull/946) now that devops has updated their version of the artifact action

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
