### PR TITLE
[DCJ-322][risk=no] Remove error endpoint

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/StatusResource.java
@@ -3,13 +3,12 @@ package org.broadinstitute.dsde.consent.ontology.resources;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.Inject;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.broadinstitute.dsde.consent.ontology.OntologyLogger;
 import org.broadinstitute.dsde.consent.ontology.cloudstore.GCSHealthCheck;
 import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchHealthCheck;
@@ -25,14 +24,6 @@ public class StatusResource implements OntologyLogger {
   @Inject
   public StatusResource(HealthCheckRegistry healthChecks) {
     this.healthChecks = healthChecks;
-  }
-
-  @GET
-  @Produces("application/json")
-  @Path("error")
-  public Response error(@QueryParam("message") String message) {
-    logError(String.format("Logged Exception: %s", message));
-    return Response.ok().build();
   }
 
   @GET

--- a/src/main/resources/assets/api-docs.yaml
+++ b/src/main/resources/assets/api-docs.yaml
@@ -293,23 +293,6 @@ paths:
           description: All systems are OK
         500:
           description: Some number of subsystems are not OK.
-  /status/error:
-    get:
-      summary: Generate a logged error
-      description: Generate a logged error
-      parameters:
-        - in: query
-          name: message
-          description: Message to log as an error
-          required: false
-          type: string
-      tags:
-        - Status
-      responses:
-        200:
-          description: Error successfully logged
-        500:
-          description: Other error
 
   /liveness:
     get:


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-322

### Summary
We're seeing users hitting this endpoint in production. It was essentially a testing endpoint to check sentry logging but is not an essential feature we're so removing it to reduce client errors.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
