### PR TITLE
DCJ-400: Update to java 21

### DIFF
--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: 'maven'
       - name: Bee Create
         uses: broadinstitute/workflow-dispatch@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM maven:3.8.3-eclipse-temurin-17 AS build
+FROM maven:3.9.7-eclipse-temurin-21 AS build
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -11,5 +11,5 @@ COPY src /usr/src/app/src
 RUN mvn clean package -Dmaven.test.skip=true
 
 # Published
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:21-debian
 COPY --from=build /usr/src/app/target/consent-ontology.jar /opt/consent-ontology.jar

--- a/docs/DEVNOTES.md
+++ b/docs/DEVNOTES.md
@@ -1,7 +1,7 @@
 # Local Development
 
-* Maven 3.8
-* Java 17
+* Maven 3.9
+* Java 21
 * Dropwizard Docs: http://www.dropwizard.io/
 
 ### Check out repository:

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
   <properties>
     <dropwizard.version>4.0.4</dropwizard.version>
     <logback.version>1.4.14</logback.version>
-    <java.version>17</java.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>21</java.version>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <jena.version>2.6.4</jena.version>
     <jersey.version>2.19</jersey.version>
     <junit.version>5.10.2</junit.version>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-400

### Summary

- Similar to https://github.com/DataBiosphere/consent/pull/2345
- Updates broad-dsp-gcr-public/base/jre from 17-debian to 21-debian
- Update base image, build image, smoke tests, and docs to match latest java version available.

## Testing
Testing requires [installing java 21 locally](https://adoptium.net/temurin/releases/?os=mac&package=jdk&version=21) and ensuring that your local compose file is updated as well:
```
app:
  image: us.gcr.io/broad-dsp-gcr-public/base/jre:21-debian
``` 
The app should start up and run with no regressions.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
