### PR TITLE
Revert "[DCJ-400-maven]: Bump the maven-dependencies group with 5 updates"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <jersey.version>2.19</jersey.version>
     <junit.version>5.11.3</junit.version>
     <mockserver.version>5.15.0</mockserver.version>
-    <surefire.version>3.5.2</surefire.version>
+    <surefire.version>3.5.1</surefire.version>
     <swagger.ui.version>5.17.14</swagger.ui.version>
     <swagger.ui.path>META-INF/resources/webjars/swagger-ui/${swagger.ui.version}/</swagger.ui.path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -329,7 +329,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>11.1.0</version>
+        <version>11.0.0</version>
         <configuration>
           <failBuildOnCVSS>1</failBuildOnCVSS>
           <suppressionFiles>
@@ -430,7 +430,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
-      <version>1.68.1</version>
+      <version>1.68.0</version>
     </dependency>
 
     <dependency>
@@ -500,13 +500,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.18.1</version>
+      <version>2.18.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.networknt</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>1.5.3</version>
+      <version>1.5.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Reverts DataBiosphere/consent-ontology#993

The referenced PR breaks deployment:
```
java.lang.NoSuchMethodError: 'com.fasterxml.jackson.core.JsonToken com.fasterxml.jackson.dataformat.yaml.YAMLParser._updateToken(com.fasterxml.jackson.core.JsonToken)'
	at com.fasterxml.jackson.dataformat.yaml.YAMLParser.nextToken(YAMLParser.java:532)
	at com.fasterxml.jackson.databind.ObjectMapper.readTree(ObjectMapper.java:3137)
	at io.dropwizard.configuration.BaseConfigurationFactory.build(BaseConfigurationFactory.java:86)
	at io.dropwizard.core.cli.ConfiguredCommand.parseConfiguration(ConfiguredCommand.java:139)
	at io.dropwizard.core.cli.ConfiguredCommand.run(ConfiguredCommand.java:85)
	at io.dropwizard.core.cli.Cli.run(Cli.java:78)
	at io.dropwizard.core.Application.run(Application.java:94)
	at org.broadinstitute.dsde.consent.ontology.OntologyApp.main(OntologyApp.java:48)
```