### PR TITLE
[DT-1096] Update JIRA key to DT instead of DCJ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     open-pull-requests-limit: 10
     target-branch: develop
     commit-message:
-      prefix: "[DCJ-400-actions]"
+      prefix: "[DT-400-actions]"
     groups:
       action-dependencies:
         patterns:
@@ -21,7 +21,7 @@ updates:
     labels:
       - dependency
     commit-message:
-      prefix: "[DCJ-400-maven]"
+      prefix: "[DT-400-maven]"
     groups:
       maven-dependencies:
         patterns:
@@ -35,7 +35,7 @@ updates:
     labels:
       - dependency
     commit-message:
-      prefix: "[DCJ-400-docker]"
+      prefix: "[DT-400-docker]"
     groups:
       docker-dependencies:
         patterns:


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1096

### Summary

Updates the JIRA key to `DT-` instead of `DCJ-`

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
