### PR TITLE
DT-1191: Remove dependabot restriction

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,6 @@ jobs:
         SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
         ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
     - id: 'auth'
-      if: github.actor != 'dependabot[bot]'
       name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'
       with:
@@ -67,7 +66,6 @@ jobs:
         username: 'oauth2accesstoken'
         password: '${{ steps.auth.outputs.access_token }}'
     - name: Push Image to DSP GAR
-      if: github.actor != 'dependabot[bot]'
       run: |
         gcloud auth configure-docker "$GOOGLE_PROJECT" --quiet
         docker push "${SHA_TAG}"


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1191

## Summary
Minor change to remove the dependabot restriction so dependabot PRs can successfully run image pushes.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
