### PR TITLE
[DT-400-maven][DT-1323] Only update a subset of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <dropwizard.version>4.0.11</dropwizard.version>
-    <logback.version>1.5.16</logback.version>
+    <logback.version>1.5.17</logback.version>
     <java.version>21</java.version>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
@@ -387,7 +387,7 @@
     <dependency>
       <groupId>io.sentry</groupId>
       <artifactId>sentry</artifactId>
-      <version>7.16.0</version>
+      <version>8.3.0</version>
     </dependency>
 
     <dependency>
@@ -399,7 +399,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.3.1-jre</version>
+      <version>33.4.0-jre</version>
     </dependency>
 
     <dependency>
@@ -411,13 +411,13 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.11.0</version>
+      <version>2.12.1</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.2</version>
       <exclusions>
         <exclusion>
           <groupId>io.grpc</groupId>
@@ -430,19 +430,19 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-context</artifactId>
-      <version>1.68.0</version>
+      <version>1.71.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev20241008-2.0.0</version>
+      <version>v1-rev20250224-2.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
-      <version>8.15.3</version>
+      <version>8.17.3</version>
     </dependency>
 
     <dependency>
@@ -500,13 +500,13 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.18.0</version>
+      <version>2.18.3</version>
     </dependency>
 
     <dependency>
       <groupId>com.networknt</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.6</version>
     </dependency>
 
     <dependency>
@@ -526,7 +526,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.17.0</version>
+      <version>2.18.0</version>
     </dependency>
 
     <dependency>
@@ -547,7 +547,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mockserver</artifactId>
-      <version>1.20.3</version>
+      <version>1.20.6</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
### Addresses

* https://broadworkbench.atlassian.net/browse/DT-400
* https://broadworkbench.atlassian.net/browse/DT-1323

### Summary

Updates only the least risky dependencies:

| Package | From | To |
| --- | --- | --- |
| [ch.qos.logback:logback-classic](https://github.com/qos-ch/logback) | `1.5.16` | `1.5.17` |
| [ch.qos.logback:logback-core](https://github.com/qos-ch/logback) | `1.5.16` | `1.5.17` |
| [io.sentry:sentry](https://github.com/getsentry/sentry-java) | `7.16.0` | `8.3.0` |
| [com.google.guava:guava](https://github.com/google/guava) | `33.3.1-jre` | `33.4.0-jre` |
| [com.google.code.gson:gson](https://github.com/google/gson) | `2.11.0` | `2.12.1` |
| [com.google.api-client:google-api-client](https://github.com/googleapis/google-api-java-client) | `2.7.0` | `2.7.2` |
| [io.grpc:grpc-context](https://github.com/grpc/grpc-java) | `1.68.0` | `1.71.0` |
| com.google.apis:google-api-services-storage | `v1-rev20241008-2.0.0` | `v1-rev20250224-2.0.0` |
| [org.elasticsearch.client:elasticsearch-rest-client](https://github.com/elastic/elasticsearch) | `8.15.3` | `8.17.3` |
| [com.fasterxml.jackson.core:jackson-annotations](https://github.com/FasterXML/jackson) | `2.18.0` | `2.18.3` |
| [com.networknt:json-schema-validator](https://github.com/networknt/json-schema-validator) | `1.5.2` | `1.5.6` |
| commons-io:commons-io | `2.17.0` | `2.18.0` |
| [org.testcontainers:mockserver](https://github.com/testcontainers/testcontainers-java) | `1.20.3` | `1.20.6` |

I'll update the next set separately.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
