### PR TITLE
DT-1668: Remove coveralls in favor of sonar coverage reporting

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,3 +1,4 @@
+# Note that the sonar token used for this action is maintained in Google Secrets Manager by Devops
 name: Coverage
 on:
   push:
@@ -34,9 +35,8 @@ jobs:
         continue-on-error: true
         if: github.actor != 'dependabot[bot]'
         env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report --batch-mode
-          mvn coveralls:report -DrepoToken=$COVERALLS_TOKEN --batch-mode
+          mvn clean jacoco:prepare-agent test jacoco:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --batch-mode

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Consent Ontology Services
 
 [![Build Status](https://circleci.com/gh/DataBiosphere/consent-ontology.svg?style=svg)](https://circleci.com/gh/DataBiosphere/consent-ontology)
-[![Coverage Status](https://coveralls.io/repos/github/DataBiosphere/consent-ontology/badge.svg?branch=develop)](https://coveralls.io/github/DataBiosphere/consent-ontology?branch=develop)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_consent_ontology&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_consent_ontology)
 
 The primary Ontology Service API layer for the Data Use Oversight System [DUOS](https://github.com/databiosphere/duos-ui)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Consent Ontology Services
 
 [![Build Status](https://circleci.com/gh/DataBiosphere/consent-ontology.svg?style=svg)](https://circleci.com/gh/DataBiosphere/consent-ontology)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_consent_ontology&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_consent_ontology)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_consent-ontology&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_consent-ontology)
 
 The primary Ontology Service API layer for the Data Use Oversight System [DUOS](https://github.com/databiosphere/duos-ui)
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <mockito.version>5.18.0</mockito.version>
+    <sonar.plugin.version>5.1.0.4751</sonar.plugin.version>
+    <sonar.organization>broad-databiosphere</sonar.organization>
+    <sonar.projectKey>DataBiosphere_consent_ontology</sonar.projectKey>
+    <sonar.projectName>consent_ontology</sonar.projectName>
   </properties>
 
   <profiles>
@@ -238,20 +242,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.3.0</version>
-        <!-- java 11 requirement for coveralls support-->
-        <dependencies>
-          <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.13</version>
@@ -332,6 +322,17 @@
       </plugin>
 
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <version>${sonar.plugin.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
   </build>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
     <mockito.version>5.18.0</mockito.version>
     <sonar.plugin.version>5.1.0.4751</sonar.plugin.version>
     <sonar.organization>broad-databiosphere</sonar.organization>
-    <sonar.projectKey>DataBiosphere_consent_ontology</sonar.projectKey>
-    <sonar.projectName>consent_ontology</sonar.projectName>
+    <sonar.projectKey>DataBiosphere_consent-ontology</sonar.projectKey>
+    <sonar.projectName>consent-ontology</sonar.projectName>
   </properties>
 
   <profiles>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1668

### Summary
Use sonar for coverage instead of coveralls

See https://sonarcloud.io/project/overview?id=DataBiosphere_consent-ontology for this project's details in Sonarcloud

See also: https://github.com/DataBiosphere/consent/pull/2650

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
