### PR TITLE
DT-2289: Upgrade to Dropwizard 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,6 +541,7 @@
     </dependency>
 
     <!-- Required for mocking elastic search responses -->
+    <!--suppress VulnerableLibrariesLocal -->
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mockserver</artifactId>
@@ -549,6 +550,7 @@
     </dependency>
 
     <!-- Required for mocking client calls against elastic search -->
+    <!--suppress VulnerableLibrariesLocal -->
     <dependency>
       <groupId>org.mock-server</groupId>
       <artifactId>mockserver-client-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <name>Consent Management: Ontology Services</name>
 
   <properties>
-    <dropwizard.version>4.0.11</dropwizard.version>
+    <dropwizard.version>5.0.0</dropwizard.version>
     <logback.version>1.5.18</logback.version>
     <java.version>21</java.version>
     <maven.compiler.source>21</maven.compiler.source>
@@ -493,18 +493,11 @@
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-http2</artifactId>
       <version>${dropwizard.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.eclipse.jetty.http2</groupId>
-          <artifactId>http2-common</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
-    <!-- OWASP dependency vulnerability: http2-common-11.0.16.jar 10/12/2023 -->
     <dependency>
-      <groupId>org.eclipse.jetty.http2</groupId>
-      <artifactId>http2-common</artifactId>
+      <groupId>org.eclipse.jetty.http3</groupId>
+      <artifactId>http3-common</artifactId>
       <version>11.0.26</version>
     </dependency>
 

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/OntologyApp.java
@@ -23,7 +23,7 @@ import org.broadinstitute.dsde.consent.ontology.resources.SwaggerResource;
 import org.broadinstitute.dsde.consent.ontology.resources.TranslateResource;
 import org.broadinstitute.dsde.consent.ontology.resources.VersionResource;
 import org.broadinstitute.dsde.consent.ontology.service.ElasticSearchHealthCheck;
-import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
+import org.eclipse.jetty.ee10.servlet.ErrorPageErrorHandler;
 
 /**
  * Top-level entry point to the entire application.

--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResource.java
@@ -1,15 +1,14 @@
 package org.broadinstitute.dsde.consent.ontology.resources;
 
-import java.net.URLDecoder;
-import java.nio.charset.Charset;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import org.broadinstitute.dsde.consent.ontology.model.Error;
-import org.eclipse.jetty.server.Request;
 
 @Path("error")
 public class ErrorResource {
@@ -18,7 +17,7 @@ public class ErrorResource {
   @Path("404")
   @Produces("application/json")
   public Response notFound(@Context HttpServletRequest request) {
-    String originalUri = ((Request) request).getOriginalURI();
+    String originalUri = request.getRequestURI();
     String decodedUri = URLDecoder.decode(originalUri, Charset.defaultCharset());
     String msg = String.format("Unable to find requested path: '%s'", decodedUri);
     Error error = new Error(msg, 404);

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResourceTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResourceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
@@ -18,12 +19,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ErrorResourceTest {
 
   @Mock
-  private Request request;
+  private HttpServletRequest request;
 
   @Test
   void testNotFound() {
     ErrorResource resource = new ErrorResource();
-    when(request.getOriginalURI()).thenReturn("not_found");
+    when(request.getRequestURI()).thenReturn("not_found");
     try (Response response = resource.notFound(request)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
     }
@@ -34,7 +35,7 @@ class ErrorResourceTest {
     String unicode = "¥";
     String encoded = URLEncoder.encode(unicode, Charset.defaultCharset());
     ErrorResource resource = new ErrorResource();
-    when(request.getOriginalURI()).thenReturn(encoded);
+    when(request.getRequestURI()).thenReturn(encoded);
     try (Response response = resource.notFound(request)) {
       assertTrue(response.getEntity().toString().contains(unicode));
     }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResourceTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResourceTest.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.core.Response;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
-import org.eclipse.jetty.server.Request;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-2289

## Summary
Upgrade Ontology to Dropwizard 5.
Minor updates to error handler to accommodate the changes necessary for the jetty library update.

### Testing
To test [locally](https://local.dsde-dev.broadinstitute.org:28443/), it helps to be on the VPN to connect to our dev ES instance. All APIs are un-authenticated so are pretty easily tested in swagger

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
