### PR TITLE
DT-2289: Update 404 handling to work with new Jetty wrappers

### DIFF
--- a/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResource.java
+++ b/src/main/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResource.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.consent.ontology.resources;
 
+import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -9,19 +11,38 @@ import jakarta.ws.rs.core.Response;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import org.broadinstitute.dsde.consent.ontology.model.Error;
+import org.eclipse.jetty.ee10.servlet.ServletApiRequest;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler.ServletRequestInfo;
 
 @Path("error")
 public class ErrorResource {
 
+  /**
+   * Explanatory note about this 404 handler:
+   * In order to provide the original URI that resulted in a 404, we need to access the underlying
+   * request information. The HttpServletRequest passed to this method is actually a wrapper around
+   * the original request. By unwrapping it to get to the ServletApiRequest, we can retrieve the
+   * original URI that was requested. This allows us to construct a more informative error message
+   * for the client.
+   * @param httpServletRequest The HttpServletRequest
+   * @return Response
+   */
   @GET
   @Path("404")
   @Produces("application/json")
-  public Response notFound(@Context HttpServletRequest request) {
-    String originalUri = request.getRequestURI();
-    String decodedUri = URLDecoder.decode(originalUri, Charset.defaultCharset());
-    String msg = String.format("Unable to find requested path: '%s'", decodedUri);
-    Error error = new Error(msg, 404);
-    return Response.status(error.code()).entity(error).build();
+  public Response notFound(@Context HttpServletRequest httpServletRequest) {
+    try {
+      HttpServletRequestWrapper requestWrapper = (HttpServletRequestWrapper) httpServletRequest;
+      ServletRequest servletRequest = requestWrapper.getRequest();
+      ServletApiRequest servletApiRequest = (ServletApiRequest) servletRequest;
+      ServletRequestInfo servletRequestInfo = servletApiRequest.getServletRequestInfo();
+      String originalUri = servletRequestInfo.getDecodedPathInContext();
+      String decodedUri = URLDecoder.decode(originalUri, Charset.defaultCharset());
+      String msg = String.format("Unable to find requested path: %s", decodedUri);
+      Error error = new Error(msg, Response.Status.NOT_FOUND.getStatusCode());
+      return Response.status(Response.Status.NOT_FOUND).entity(error).build();
+    } catch (Exception e) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
   }
-
 }

--- a/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResourceTest.java
+++ b/src/test/java/org/broadinstitute/dsde/consent/ontology/resources/ErrorResourceTest.java
@@ -5,12 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpStatusCodes;
-import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.ws.rs.core.Response;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import org.junit.jupiter.api.Test;
+import org.eclipse.jetty.ee10.servlet.ServletApiRequest;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler.ServletRequestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -18,26 +19,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ErrorResourceTest {
 
   @Mock
-  private HttpServletRequest request;
+  private HttpServletRequestWrapper request;
+  @Mock
+  private ServletApiRequest servletRequest;
+  @Mock
+  private ServletRequestInfo servletRequestInfo;
 
-  @Test
-  void testNotFound() {
+  @ParameterizedTest
+  @ValueSource(strings = {"/not_found", "/context/¥"})
+  void testNotFound(String path) {
     ErrorResource resource = new ErrorResource();
-    when(request.getRequestURI()).thenReturn("not_found");
+    when(request.getRequest()).thenReturn(servletRequest);
+    when(servletRequest.getServletRequestInfo()).thenReturn(servletRequestInfo);
+    when(servletRequestInfo.getDecodedPathInContext()).thenReturn(path);
     try (Response response = resource.notFound(request)) {
       assertEquals(HttpStatusCodes.STATUS_CODE_NOT_FOUND, response.getStatus());
+      assertTrue(response.getEntity().toString().contains(path));
     }
   }
-
-  @Test
-  void testNotFoundDecoded() {
-    String unicode = "¥";
-    String encoded = URLEncoder.encode(unicode, Charset.defaultCharset());
-    ErrorResource resource = new ErrorResource();
-    when(request.getRequestURI()).thenReturn(encoded);
-    try (Response response = resource.notFound(request)) {
-      assertTrue(response.getEntity().toString().contains(unicode));
-    }
-  }
-
 }


### PR DESCRIPTION
### Addresses
Error handling for the DW5 update in https://broadworkbench.atlassian.net/browse/DT-2289

### Summary
Minor update to the 404 handler to unwrap the original request to get the original failure url.

See also the same treatment in https://github.com/DataBiosphere/consent/pull/2714

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
