### PR TITLE
DT-2753: Ensure that failing tests fail the action

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -3,10 +3,10 @@ name: Coverage
 on:
   push:
     branches:
-    - develop
+      - develop
   pull_request:
     branches:
-    - develop
+      - develop
 jobs:
   package:
     name: Coverage
@@ -21,23 +21,16 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 25
-      - uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: 'maven'
       - name: Test Only
-        if: github.actor == 'dependabot[bot]'
         env:
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-        run: mvn clean test --batch-mode
+        run: mvn clean jacoco:prepare-agent test jacoco:report --batch-mode
       - name: Test Report
         continue-on-error: true
-        if: github.actor != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         run: |
           mvn -v
-          mvn clean jacoco:prepare-agent test jacoco:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --batch-mode
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar --batch-mode


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2753

### Summary
See the fixes made here in Consent: https://github.com/DataBiosphere/consent/pull/2717/changes#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1f

This PR aligns with those changes. See this closed PR for an example of failing tests that correctly failed the action with these changes: https://github.com/DataBiosphere/consent-ontology/pull/1080

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
